### PR TITLE
TIM-396 REFACTOR(pending): mode of premium to mode of payment in forms

### DIFF
--- a/src/app/(dashboard)/(home)/pending/forms/pending-inputs.tsx
+++ b/src/app/(dashboard)/(home)/pending/forms/pending-inputs.tsx
@@ -41,8 +41,8 @@ const PendingInputs: FC<Props> = ({ isLoading }) => {
   const form = useFormContext<z.infer<typeof pendingSchema>>()
   const supabase = createBrowserClient()
 
-  const { data: modeOfPremiums, isLoading: isModeOfPremiumLoading } = useQuery(
-    getTypes(supabase, 'mode_of_premium'),
+  const { data: modeOfPayments, isLoading: isModeOfPaymentLoading } = useQuery(
+    getTypes(supabase, 'mode_of_payments'),
   )
 
   const handleInputChange = (
@@ -58,18 +58,18 @@ const PendingInputs: FC<Props> = ({ isLoading }) => {
       <div className="grid grid-cols-2 gap-4">
         <FormField
           control={form.control}
-          name="mode_of_premium_id"
+          name="mode_of_payment_id"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Mode of Premium</FormLabel>
+              <FormLabel>Mode of Payment</FormLabel>
               <Select onValueChange={field.onChange}>
                 <FormControl>
-                  <SelectTrigger disabled={isModeOfPremiumLoading || isLoading}>
-                    <SelectValue placeholder="Select HMO Provider" />
+                  <SelectTrigger disabled={isModeOfPaymentLoading || isLoading}>
+                    <SelectValue placeholder="Select Mode of Payment" />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {modeOfPremiums?.map((mode) => (
+                  {modeOfPayments?.map((mode) => (
                     <SelectItem key={mode.id} value={mode.id}>
                       {mode.name}
                     </SelectItem>

--- a/src/app/(dashboard)/(home)/pending/forms/pending-schema.ts
+++ b/src/app/(dashboard)/(home)/pending/forms/pending-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 const pendingSchema = z.object({
-  mode_of_premium_id: z.string().nullable(),
+  mode_of_payment_id: z.string().nullable(),
   due_date: z.date().nullable(),
   or_number: z.string().nullable(),
   or_date: z.date().nullable(),

--- a/src/app/(dashboard)/(home)/pending/update-pending-form.tsx
+++ b/src/app/(dashboard)/(home)/pending/update-pending-form.tsx
@@ -24,7 +24,7 @@ const UpdatePendingForm: FC<Props> = ({ accountId, setOpenForm }) => {
   const form = useForm<z.infer<typeof pendingSchema>>({
     resolver: zodResolver(pendingSchema),
     defaultValues: {
-      mode_of_premium_id: null,
+      mode_of_payment_id: null,
       due_date: null,
       or_number: null,
       or_date: null,
@@ -66,12 +66,12 @@ const UpdatePendingForm: FC<Props> = ({ accountId, setOpenForm }) => {
   const onUpdateHandler = useCallback<FormEventHandler<HTMLFormElement>>(
     (e) => {
       form.handleSubmit(async (data) => {
-        // check if mode_of_premium_id is not empty
-        if (data.mode_of_premium_id === '') {
+        // check if mode_of_payment_id is not empty
+        if (data.mode_of_payment_id === '') {
           toast({
             variant: 'destructive',
             title: 'Something went wrong',
-            description: 'Mode of premium is required',
+            description: 'Mode of payment is required',
           })
           return
         }


### PR DESCRIPTION
### TL;DR

Renamed "Mode of Premium" to "Mode of Payment" throughout the pending form components.

### What changed?

- Updated variable names and form field references from `mode_of_premium` to `mode_of_payment`
- Changed the placeholder text in the select input from "Select HMO Provider" to "Select Mode of Payment"
- Updated the schema to use `mode_of_payment_id` instead of `mode_of_premium_id`
- Modified the validation check and error message in the form submission handler

### How to test?

1. Navigate to the pending form in the dashboard
2. Verify that the dropdown label now reads "Mode of Payment"
3. Check that the placeholder text in the dropdown is "Select Mode of Payment"
4. Submit the form without selecting a mode of payment and confirm the error message reads "Mode of payment is required"

### Why make this change?

This change improves clarity and consistency in the user interface by using more accurate terminology. "Mode of Payment" better reflects the purpose of this field, which is to specify how the payment will be made, rather than implying it's specifically about premiums.