### PR TITLE
feat(accounts): add delete account function

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-about.tsx
@@ -1,25 +1,24 @@
-import React, { FC, useCallback, FormEventHandler } from 'react'
-import CompanyInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-information'
 import CompanyAccountInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-account-information'
+import CompanyCancelButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-cancel-button'
+import CompanyContractInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-contract-information'
+import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-provider'
+import companyEditsSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edits-schema'
 import CompanyFinancialInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-financial-information'
 import CompanyHMOInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-HMO-information'
-import CompanyContractInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-contract-information'
-import { createBrowserClient } from '@/utils/supabase'
+import CompanyInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-information'
+import { Button } from '@/components/ui/button'
+import { Form } from '@/components/ui/form'
+import { toast } from '@/components/ui/use-toast'
 import getAccountById from '@/queries/get-account-by-id'
-import accountsSchema from '@/app/(dashboard)/(home)/accounts/accounts-schema'
-import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+import { createBrowserClient } from '@/utils/supabase'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
   useInsertMutation,
   useQuery,
 } from '@supabase-cache-helpers/postgrest-react-query'
-import { zodResolver } from '@hookform/resolvers/zod'
+import { FC, FormEventHandler, useCallback } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
 import { z } from 'zod'
-import { toast } from '@/components/ui/use-toast'
-import { Form } from '@/components/ui/form'
-import { Button } from '@/components/ui/button'
-import CompanyCancelButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-cancel-button'
-import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-provider'
-import companyEditsSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edits-schema'
 
 interface Props {
   companyId: string

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-delete-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-delete-button.tsx
@@ -1,0 +1,154 @@
+'use client'
+import { DeleteCompanySchema } from '@/app/(dashboard)/(home)/accounts/(Personnel)/delete-company-schema'
+import {
+  AlertDialogHeader,
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogTrigger,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { useToast } from '@/components/ui/use-toast'
+import getAccountById from '@/queries/get-account-by-id'
+import { createBrowserClient } from '@/utils/supabase'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  useQuery,
+  useUpdateMutation,
+} from '@supabase-cache-helpers/postgrest-react-query'
+import { Trash, X } from 'lucide-react'
+import { FC, FormEventHandler, useCallback, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+interface Props {
+  accountId: string
+}
+
+const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const { toast } = useToast()
+  const form = useForm<z.infer<typeof DeleteCompanySchema>>({
+    resolver: zodResolver(DeleteCompanySchema),
+    defaultValues: {
+      companyName: '',
+    },
+  })
+
+  const supabase = createBrowserClient()
+  const { data: account } = useQuery(getAccountById(supabase, accountId))
+
+  const { mutateAsync, isPending } = useUpdateMutation(
+    // @ts-ignore
+    supabase.from('accounts'),
+    ['id'],
+    'id',
+    {
+      onSuccess: () => {
+        setIsOpen(false)
+        form.reset()
+        toast({
+          variant: 'default',
+          title: 'Success',
+          description: 'Account deleted',
+        })
+      },
+      onError: (error) => {
+        console.log(error)
+        toast({
+          variant: 'destructive',
+          title: 'Something went wrong',
+          description: error.message,
+        })
+      },
+    },
+  )
+
+  const onUpdateHandler = useCallback<FormEventHandler<HTMLFormElement>>(
+    (e) => {
+      form.handleSubmit(async (data) => {
+        // check if companyName is same as account?.company_name
+        if (data.companyName !== account?.company_name) {
+          form.setError('companyName', {
+            type: 'manual',
+            message: 'Company name does not match',
+          })
+          return
+        }
+
+        await mutateAsync({
+          id: accountId,
+          is_active: false,
+        })
+      })(e)
+    },
+    [account?.company_name, accountId, form, mutateAsync],
+  )
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild={true}>
+        <Button className="w-fit rounded-md" variant={'destructive'}>
+          <Trash />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <Form {...form}>
+          <form onSubmit={onUpdateHandler}>
+            <AlertDialogCancel className="absolute right-5 top-5 h-fit w-fit border-0 p-0">
+              <X className="h-4 w-4" />
+            </AlertDialogCancel>
+            <AlertDialogHeader className="mb-3">
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+              <AlertDialogDescription className="text-black">
+                This action <span className="font-bold">CANNOT</span> be undone.
+                This will permanently delete the{' '}
+                <span className="font-bold">{account?.company_name}</span>{' '}
+                account.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <FormField
+              control={form.control}
+              name="companyName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Please type in the name of the account to confirm.
+                  </FormLabel>
+                  <FormControl>
+                    <Input {...field} disabled={isPending} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <AlertDialogFooter className="mt-3">
+              <Button
+                className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                type="submit"
+                disabled={isPending}
+              >
+                I understand, delete this account
+              </Button>
+            </AlertDialogFooter>
+          </form>
+        </Form>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default CompanyDeleteButton

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-button.tsx
@@ -12,7 +12,7 @@ const CompanyEditButton = () => {
     <>
       {!editMode && (
         <Button
-          className="m-4 gap-2 rounded-md"
+          className="w-full gap-2 rounded-md md:max-w-xs"
           onClick={() => setEditMode(true)}
         >
           <Pencil /> <span> Edit Company Details </span>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-page.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-page.tsx
@@ -1,26 +1,24 @@
 'use client'
 
-import React, { FC, useState } from 'react'
-import CompanyHeader from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header'
-import { Tabs, TabsContent } from '@/components/ui/tabs'
 import CompanyAbout from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-about'
-import EmployeesPage from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/employees-page'
-import EmployeesAddPersonnelForm from './employees-add-personnel-form'
+import CompanyEditButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-button'
+import CompanyEditProvider from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-provider'
+import CompanyHeader from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-provider'
 import AddPersonnelButtonForm from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/employees-add-personnel-button-form'
-import { Button } from '@/components/ui/button'
-import { Pencil } from 'lucide-react'
-import CompanyEditProvider, {
-  useCompanyEditContext,
-} from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-provider'
-import CompanyEditButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-edit-button'
+import EmployeesPage from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/employees-page'
+import { Tabs, TabsContent } from '@/components/ui/tabs'
+import { FC } from 'react'
+import EmployeesAddPersonnelForm from './employees-add-personnel-form'
+import CompanyDeleteButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-delete-button'
 
 interface Props {
   companyId: string
+  role: string | null
 }
 
-const CompanyPage: FC<Props> = ({ companyId }) => {
-  const { showAddPersonnel, setShowAddPersonnel } = useCompanyContext()
+const CompanyPage: FC<Props> = ({ companyId, role }) => {
+  const { showAddPersonnel } = useCompanyContext()
 
   return (
     <Tabs defaultValue="about">
@@ -28,8 +26,11 @@ const CompanyPage: FC<Props> = ({ companyId }) => {
       <div className="p-8 lg:mx-auto lg:max-w-5xl">
         <TabsContent value="about">
           <CompanyEditProvider>
-            <div className="ml-auto flex w-full flex-col lg:items-end lg:justify-center">
+            <div className="flex w-full flex-row items-center gap-4 pb-4 md:justify-end">
               <CompanyEditButton />
+              {role === 'marketing' && (
+                <CompanyDeleteButton accountId={companyId} />
+              )}
             </div>
             <CompanyAbout companyId={companyId} />
           </CompanyEditProvider>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/page.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/page.tsx
@@ -11,16 +11,19 @@ import {
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getAccountById from '@/queries/get-account-by-id'
 import CompanyProvider from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-provider'
+import getRole from '@/utils/get-role'
 
 const Page = async ({ params }: { params: { id: string } }) => {
   const supabase = createServerClient(cookies())
   const queryClient = new QueryClient()
 
   await prefetchQuery(queryClient, getAccountById(supabase, params.id))
+
+  const role = await getRole()
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <CompanyProvider>
-        <CompanyPage companyId={params.id} />
+        <CompanyPage companyId={params.id} role={role} />
       </CompanyProvider>
     </HydrationBoundary>
   )

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/delete-company-schema.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/delete-company-schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const DeleteCompanySchema = z.object({
+  companyName: z.string().min(1, { message: 'Company name is required' }),
+})


### PR DESCRIPTION
### TL;DR

Added a company delete functionality and improved the layout of company edit and delete buttons.

### What changed?

- Introduced a new `CompanyDeleteButton` component for deleting company accounts
- Added a delete company schema for form validation
- Updated the `CompanyPage` component to include the delete button for users with the 'marketing' role
- Improved the layout and styling of edit and delete buttons
- Refactored imports and removed unused code in `company-about.tsx`
- Updated the `CompanyEditButton` styling for better responsiveness

### How to test?

1. Log in as a user with the 'marketing' role
2. Navigate to a company's page
3. Verify that both edit and delete buttons are visible
4. Click the delete button and attempt to delete the company
5. Confirm that the deletion process requires entering the company name
6. Test the deletion process with both correct and incorrect company names
7. Verify that the account is marked as inactive after successful deletion

### Why make this change?

This change provides authorized users with the ability to delete company accounts when necessary, improving account management capabilities. The improved layout and styling of the buttons enhance the user interface and make the actions more accessible. The addition of role-based access to the delete functionality ensures that only users with appropriate permissions can perform this critical action.