### PR TITLE
TIM-435 feat(billing-statements): add billing statements page

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
+++ b/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
@@ -4,8 +4,6 @@ import getAccounts from '@/queries/get-accounts'
 import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
 
-type getAccountsResponse = Awaited<ReturnType<typeof getAccounts>>
-
 const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
   {
     accessorKey: 'company_name',

--- a/src/app/(dashboard)/(home)/billing-statements/data-table-row.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/data-table-row.tsx
@@ -1,0 +1,54 @@
+import { Sheet, SheetTrigger } from '@/components/ui/sheet'
+import { TableCell, TableRow } from '@/components/ui/table'
+import { Column, ColumnDef, Table, flexRender } from '@tanstack/react-table'
+import { useState } from 'react'
+import UpdatePendingForm from './update-pending-form'
+
+interface TableRowProps<TData> {
+  table: Table<TData>
+  columns: ColumnDef<TData>[]
+}
+
+const DataTableRow = <TData,>({ table, columns }: TableRowProps<TData>) => {
+  const [openForm, setOpenForm] = useState<string | null>(null)
+
+  return (
+    <>
+      {table.getRowModel().rows?.length ? (
+        table.getRowModel().rows.map((row) => (
+          <>
+            <TableRow
+              key={row.id}
+              data-state={row.getIsSelected() && 'selected'}
+              onClick={() => setOpenForm(row.id)}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+
+            {openForm === row.id && (
+              <TableCell colSpan={columns.length}>
+                <UpdatePendingForm
+                  // @ts-ignore
+                  accountId={row.original.id}
+                  setOpenForm={setOpenForm}
+                />
+              </TableCell>
+            )}
+          </>
+        ))
+      ) : (
+        <TableRow>
+          <TableCell colSpan={columns.length} className="h-16 text-center">
+            No results.
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+
+export default DataTableRow

--- a/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import {
+  PageDescription,
+  PageHeader,
+  PageTitle,
+} from '@/components/page-header'
+import TablePagination from '@/components/table-pagination'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Search } from 'lucide-react'
+import { useState } from 'react'
+
+import TableViewOptions from '@/components/table-view-options'
+import DataTableRow from './data-table-row'
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+}
+
+const DataTable = <TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) => {
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onColumnFiltersChange: setColumnFilters,
+    getFilteredRowModel: getFilteredRowModel(),
+    state: {
+      columnFilters,
+    },
+  })
+  return (
+    // <AccountsProvider>
+    <div className="flex flex-col">
+      <PageHeader>
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:justify-between">
+          <div>
+            <PageTitle>Pending</PageTitle>
+            <PageDescription>5 Accounts</PageDescription>
+          </div>
+          <div className="flex flex-row gap-4">
+            <div className="relative">
+              <Search className="absolute left-3.5 top-3.5 h-5 w-5 text-[#94a3b8]" />
+              <Input
+                className="max-w-xs rounded-full pl-10"
+                placeholder="Search accounts"
+                value={
+                  (table
+                    .getColumn('company_name')
+                    ?.getFilterValue() as string) ?? ''
+                }
+                onChange={(event) =>
+                  table
+                    .getColumn('company_name')
+                    ?.setFilterValue(event.target.value)
+                }
+              />
+            </div>
+            {/* <AddAccountButton /> */}
+          </div>
+        </div>
+      </PageHeader>
+      {/* <TableViewOptions table={table} /> */}
+      <div className="flex h-full flex-col justify-between bg-card">
+        <div className="h-full rounded-md border">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {/* @ts-ignore */}
+              <DataTableRow table={table} columns={columns} />
+            </TableBody>
+          </Table>
+        </div>
+        <TablePagination table={table} />
+      </div>
+    </div>
+    // </AccountsProvider>
+  )
+}
+
+export default DataTable

--- a/src/app/(dashboard)/(home)/billing-statements/forms/disabled-inputs.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/forms/disabled-inputs.tsx
@@ -1,0 +1,464 @@
+import { Button } from '@/components/ui/button'
+import {
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import getAccountById from '@/queries/get-account-by-id'
+import { createBrowserClient } from '@/utils/supabase'
+import { cn } from '@/utils/tailwind'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { format } from 'date-fns'
+import { CalendarIcon } from 'lucide-react'
+import { FC } from 'react'
+
+interface Props {
+  isLoading: boolean
+  id: string
+}
+
+const DisabledInputs: FC<Props> = ({ isLoading, id }) => {
+  const supabase = createBrowserClient()
+
+  const { data: account } = useQuery(getAccountById(supabase, id))
+
+  return (
+    <>
+      <FormItem>
+        <FormLabel>Agent</FormLabel>
+
+        <FormMessage />
+      </FormItem>
+
+      <FormItem>
+        <FormLabel>Company Name</FormLabel>
+        <FormControl>
+          <Input disabled={true} value={account?.company_name || ''} />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+
+      <FormItem>
+        <FormLabel>Company Address</FormLabel>
+        <FormControl>
+          <Input disabled={true} value={account?.company_address || ''} />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+
+      <FormItem>
+        <FormLabel>Nature of Business</FormLabel>
+        <FormControl>
+          <Input disabled={true} value={account?.nature_of_business || ''} />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+      <div className="grid grid-cols-2 gap-4">
+        <FormItem>
+          <FormLabel>HMO Provider</FormLabel>
+          <Select
+            value={
+              account?.hmo_provider
+                ? // @ts-ignore
+                  account?.hmo_provider.name
+                : 'hmoProvider'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select HMO Provider" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.hmo_provider
+                    ? // @ts-ignore
+                      account?.hmo_provider.name
+                    : 'hmoProvider'
+                }
+              >
+                {account?.hmo_provider
+                  ? // @ts-ignore
+                    account?.hmo_provider.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Previous HMO Provider</FormLabel>
+          <Select
+            value={
+              account?.previous_hmo_provider
+                ? // @ts-ignore
+                  account?.previous_hmo_provider.name
+                : 'previousHmoProvider'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select Previous HMO Provider" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.previous_hmo_provider
+                    ? // @ts-ignore
+                      account?.previous_hmo_provider.name
+                    : 'prevHmoProvider'
+                }
+              >
+                {account?.previous_hmo_provider
+                  ? // @ts-ignore
+                    account?.previous_hmo_provider.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <FormItem>
+          <FormLabel>Current HMO Provider</FormLabel>
+          <Select
+            value={
+              account?.hmo_provider
+                ? // @ts-ignore
+                  account?.hmo_provider.name
+                : 'currentHmoProvider'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select Current HMO Provider" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.hmo_provider
+                    ? // @ts-ignore
+                      account?.hmo_provider.name
+                    : 'currentHmoProvider'
+                }
+              >
+                {account?.hmo_provider
+                  ? // @ts-ignore
+                    account?.hmo_provider.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Account Type</FormLabel>
+          <Select
+            value={
+              account?.account_type
+                ? // @ts-ignore
+                  account?.account_type.name
+                : 'accountType'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select Account Type" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.account_type
+                    ? // @ts-ignore
+                      account?.account_type.name
+                    : 'accountType'
+                }
+              >
+                {account?.account_type
+                  ? // @ts-ignore
+                    account?.account_type.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        <FormItem>
+          <FormLabel>Total Utilization</FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              disabled={true}
+              value={account?.total_utilization || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Total Premium Paid</FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              disabled={true}
+              value={account?.total_premium_paid || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Signatory Designation</FormLabel>
+          <FormControl>
+            <Input
+              disabled={true}
+              value={account?.signatory_designation || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <FormItem>
+          <FormLabel>Contact Person</FormLabel>
+          <FormControl>
+            <Input disabled={true} value={account?.contact_person || ''} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Contact Number</FormLabel>
+          <FormControl>
+            <Input
+              type="tel"
+              disabled={true}
+              value={account?.contact_number || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Principal Plan Type</FormLabel>
+          <Select
+            value={
+              account?.principal_plan_type
+                ? // @ts-ignore
+                  account?.principal_plan_type.name
+                : 'principalPlanType'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select Principal Plan Type" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.principal_plan_type
+                    ? // @ts-ignore
+                      account?.principal_plan_type.name
+                    : 'principalPlanType'
+                }
+              >
+                {account?.principal_plan_type
+                  ? // @ts-ignore
+                    account?.principal_plan_type.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Dependent Plan Type</FormLabel>
+          <Select
+            value={
+              account?.dependent_plan_type
+                ? // @ts-ignore
+                  account?.dependent_plan_type.name
+                : 'dependentPlanType'
+            }
+            disabled={true}
+          >
+            <FormControl>
+              <SelectTrigger disabled={isLoading}>
+                <SelectValue placeholder="Select Dependent Plan Type" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem
+                value={
+                  account?.dependent_plan_type
+                    ? // @ts-ignore
+                      account?.dependent_plan_type.name
+                    : 'dependentPlanType'
+                }
+              >
+                {account?.dependent_plan_type
+                  ? // @ts-ignore
+                    account?.dependent_plan_type.name
+                  : ''}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Initial Head Count</FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              disabled={true}
+              value={account?.initial_head_count || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Effectivity Date</FormLabel>
+          <FormControl>
+            <Button
+              variant={'outline'}
+              className={cn(
+                'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-left text-sm font-normal shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+              disabled={true}
+            >
+              {account?.effectivity_date
+                ? format(new Date(account.effectivity_date), 'MMM dd, yyyy')
+                : ''}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>COC Issue Date</FormLabel>
+          <FormControl>
+            <Button
+              variant={'outline'}
+              className={cn(
+                'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-left text-sm font-normal shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+              disabled={true}
+            >
+              {account?.coc_issue_date
+                ? format(new Date(account.coc_issue_date), 'MMM dd, yyyy')
+                : ''}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Name of Signatory</FormLabel>
+          <FormControl>
+            <Input disabled={true} value={account?.name_of_signatory || ''} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Designation of Contact Person</FormLabel>
+          <FormControl>
+            <Input
+              disabled={true}
+              value={account?.designation_of_contact_person || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Email Address of Contact Person</FormLabel>
+          <FormControl>
+            <Input
+              disabled={true}
+              value={account?.email_address_of_contact_person || ''}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <FormItem>
+          <FormLabel>Expiration Date</FormLabel>
+          <FormControl>
+            <Button
+              variant={'outline'}
+              className={cn(
+                'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-left text-sm font-normal shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+              disabled={true}
+            >
+              {account?.expiration_date
+                ? format(new Date(account.expiration_date), 'MMM dd, yyyy')
+                : ''}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Delivery Date of Membership IDs</FormLabel>
+          <FormControl>
+            <Button
+              variant={'outline'}
+              className={cn(
+                'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-left text-sm font-normal shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+              disabled={true}
+            >
+              {account?.delivery_date_of_membership_ids
+                ? format(
+                    new Date(account.delivery_date_of_membership_ids),
+                    'MMM dd, yyyy',
+                  )
+                : ''}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+        <FormItem>
+          <FormLabel>Orientation Date</FormLabel>
+          <FormControl>
+            <Button
+              variant={'outline'}
+              className={cn(
+                'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-left text-sm font-normal shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+              disabled={true}
+            >
+              {account?.orientation_date
+                ? format(new Date(account.orientation_date), 'MMM dd, yyyy')
+                : ''}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      </div>
+    </>
+  )
+}
+
+export default DisabledInputs

--- a/src/app/(dashboard)/(home)/billing-statements/forms/pending-inputs.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/forms/pending-inputs.tsx
@@ -1,0 +1,287 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
+import pendingSchema from './pending-schema'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+import getTypes from '@/queries/get-types'
+import { createBrowserClient } from '@/utils/supabase'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/utils/tailwind'
+import { format } from 'date-fns'
+import { CalendarIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { FC } from 'react'
+import { ControllerRenderProps } from 'react-hook-form'
+
+interface Props {
+  isLoading: boolean
+}
+
+const PendingInputs: FC<Props> = ({ isLoading }) => {
+  const form = useFormContext<z.infer<typeof pendingSchema>>()
+  const supabase = createBrowserClient()
+
+  const { data: modeOfPayments, isLoading: isModeOfPaymentLoading } = useQuery(
+    getTypes(supabase, 'mode_of_payments'),
+  )
+
+  const handleInputChange = (
+    field: ControllerRenderProps<z.infer<typeof pendingSchema>, any>,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = e.target.value === '' ? null : e.target.value
+    field.onChange(value)
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4">
+        <FormField
+          control={form.control}
+          name="mode_of_payment_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Mode of Payment</FormLabel>
+              <Select onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger disabled={isModeOfPaymentLoading || isLoading}>
+                    <SelectValue placeholder="Select Mode of Payment" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {modeOfPayments?.map((mode) => (
+                    <SelectItem key={mode.id} value={mode.id}>
+                      {mode.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="due_date"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Due Date</FormLabel>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      variant={'outline'}
+                      className={cn(
+                        'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-sm shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                        !field.value && 'text-muted-foreground',
+                        'text-left font-normal',
+                      )}
+                      disabled={isLoading}
+                    >
+                      {field.value ? (
+                        format(field.value, 'PPP')
+                      ) : (
+                        <span>Pick a date</span>
+                      )}
+                      <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value ?? undefined}
+                    onSelect={field.onChange}
+                    disabled={(date) =>
+                      date > new Date() || date < new Date('1900-01-01')
+                    }
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+      <FormField
+        control={form.control}
+        name="or_number"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>OR Number</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="or_date"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>OR Date</FormLabel>
+            <Popover>
+              <PopoverTrigger asChild>
+                <FormControl>
+                  <Button
+                    variant={'outline'}
+                    className={cn(
+                      'flex h-12 w-full min-w-[240px] rounded-lg border border-input bg-white px-4 py-3 text-sm shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                      !field.value && 'text-muted-foreground',
+                      'text-left font-normal',
+                    )}
+                    disabled={isLoading}
+                  >
+                    {field.value ? (
+                      format(field.value, 'PPP')
+                    ) : (
+                      <span>Pick a date</span>
+                    )}
+                    <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                  </Button>
+                </FormControl>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={field.value ?? undefined}
+                  onSelect={field.onChange}
+                  disabled={(date) =>
+                    date > new Date() || date < new Date('1900-01-01')
+                  }
+                  initialFocus
+                />
+              </PopoverContent>
+            </Popover>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="sa_number"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>SA Number</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="amount"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Amount</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="total_contract_value"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Total Contract Value</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="balance"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Balance</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                type="number"
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="billing_period"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Billing Period</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                type="number"
+                min="1"
+                value={field.value ?? ''}
+                onChange={(e) => handleInputChange(field, e)}
+                disabled={isLoading}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}
+
+export default PendingInputs

--- a/src/app/(dashboard)/(home)/billing-statements/forms/pending-schema.ts
+++ b/src/app/(dashboard)/(home)/billing-statements/forms/pending-schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+const pendingSchema = z.object({
+  mode_of_payment_id: z.string().nullable(),
+  due_date: z.date().nullable(),
+  or_number: z.string().nullable(),
+  or_date: z.date().nullable(),
+  sa_number: z.string().nullable(),
+  amount: z.preprocess(
+    (val) => (val === null ? null : parseFloat(val as string)),
+    z.number().nullable(),
+  ),
+  total_contract_value: z.preprocess(
+    (val) => (val === null ? null : parseFloat(val as string)),
+    z.number().nullable(),
+  ),
+  balance: z.preprocess(
+    (val) => (val === null ? null : parseFloat(val as string)),
+    z.number().nullable(),
+  ),
+  billing_period: z.preprocess(
+    (val) => (val === null ? null : parseInt(val as string)),
+    z.number().min(1).max(31).nullable(),
+  ),
+})
+
+export default pendingSchema

--- a/src/app/(dashboard)/(home)/billing-statements/page.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/page.tsx
@@ -1,0 +1,28 @@
+'use server'
+
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import PendingTable from './pending-table'
+import { cookies } from 'next/headers'
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import { createServerClient } from '@/utils/supabase'
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query'
+import pageProtect from '@/utils/page-protect'
+
+const PendingPage = async () => {
+  const supabase = createServerClient(cookies())
+  const queryClient = new QueryClient()
+  await prefetchQuery(queryClient, getPendingAccounts(supabase))
+
+  await pageProtect('finance')
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      {/* <PendingTable /> */}
+    </HydrationBoundary>
+  )
+}
+
+export default PendingPage

--- a/src/app/(dashboard)/(home)/billing-statements/pending-columns.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/pending-columns.tsx
@@ -1,0 +1,26 @@
+import { ColumnDef } from '@tanstack/react-table'
+import TableHeader from '@/components/table-header'
+import { format } from 'date-fns'
+import { Tables } from '@/types/database.types'
+
+const pendingColumns: ColumnDef<Tables<'billing_statements'>>[] = [
+  {
+    accessorKey: 'company_name',
+    header: ({ column }) => (
+      <TableHeader column={column} title="Company Name" />
+    ),
+  },
+  {
+    accessorKey: 'agent.first_name',
+    header: ({ column }) => <TableHeader column={column} title="Agent" />,
+  },
+  {
+    accessorKey: 'created_at',
+    header: ({ column }) => <TableHeader column={column} title="Created At" />,
+    cell: ({ row }) => {
+      return <div>{format(row.getValue('created_at'), 'MMMM dd, yyyy p')}</div>
+    },
+  },
+]
+
+export default pendingColumns

--- a/src/app/(dashboard)/(home)/billing-statements/pending-table.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/pending-table.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import DataTable from './data-table'
+import pendingColumns from './pending-columns'
+
+const PendingTable = () => {
+  const supabase = createBrowserClient()
+  const { data } = useQuery(getPendingAccounts(supabase))
+
+  return <DataTable columns={pendingColumns} data={data as any} />
+}
+export default PendingTable

--- a/src/app/(dashboard)/(home)/billing-statements/update-pending-form.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/update-pending-form.tsx
@@ -1,0 +1,103 @@
+import { Form } from '@/components/ui/form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import PendingInputs from './forms/pending-inputs'
+import pendingSchema from './forms/pending-schema'
+import MarketingInputs from '../accounts/forms/marketing-inputs'
+import { Separator } from '@/components/ui/separator'
+import DisabledInputs from './forms/disabled-inputs'
+import { Button } from '@/components/ui/button'
+import { FC, FormEventHandler, useCallback } from 'react'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { createBrowserClient } from '@/utils/supabase'
+import { useToast } from '@/components/ui/use-toast'
+import { Loader2 } from 'lucide-react'
+
+interface Props {
+  accountId: string
+  setOpenForm: (_value: string | null) => void
+}
+
+const UpdatePendingForm: FC<Props> = ({ accountId, setOpenForm }) => {
+  const { toast } = useToast()
+  const form = useForm<z.infer<typeof pendingSchema>>({
+    resolver: zodResolver(pendingSchema),
+    defaultValues: {
+      mode_of_payment_id: null,
+      due_date: null,
+      or_number: null,
+      or_date: null,
+      sa_number: null,
+      amount: null,
+      total_contract_value: null,
+      balance: null,
+      billing_period: null,
+    },
+  })
+
+  const supabase = createBrowserClient()
+  const { mutateAsync, isPending } = useUpdateMutation(
+    // @ts-ignore
+    supabase.from('accounts'),
+    ['id'],
+    'id',
+    {
+      onError: (error) => {
+        toast({
+          variant: 'destructive',
+          title: 'Something went wrong',
+          description: error.message,
+        })
+      },
+      onSuccess: () => {
+        setOpenForm(null)
+        // reset form
+        form.reset()
+        toast({
+          variant: 'default',
+          title: 'Success',
+          description: 'Pending updated',
+        })
+      },
+    },
+  )
+
+  const onUpdateHandler = useCallback<FormEventHandler<HTMLFormElement>>(
+    (e) => {
+      form.handleSubmit(async (data) => {
+        // check if mode_of_payment_id is not empty
+        if (data.mode_of_payment_id === '') {
+          toast({
+            variant: 'destructive',
+            title: 'Something went wrong',
+            description: 'Mode of payment is required',
+          })
+          return
+        }
+        await mutateAsync({
+          ...data,
+          id: accountId,
+        })
+      })(e)
+    },
+    [form, mutateAsync, accountId, toast],
+  )
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onUpdateHandler}>
+        <div className="w-full space-y-5 px-8 py-5">
+          <DisabledInputs isLoading={false} id={accountId} />
+          <Separator className="my-5" />
+          <PendingInputs isLoading={isPending} />
+          <Button type="submit" disabled={isPending}>
+            {isPending ? <Loader2 className="animate-spin" /> : 'Update'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}
+
+export default UpdatePendingForm

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -1,7 +1,7 @@
 'use server'
 
 import getRole from '@/utils/get-role'
-import { BookCopy, ClipboardCheck, ListStart } from 'lucide-react'
+import { Book, BookCopy, ClipboardCheck } from 'lucide-react'
 import AdminNavigation from './admin-navigation'
 import NavigationItem from './navigation-item'
 
@@ -41,9 +41,9 @@ const Navigation = async () => {
             // only show pending tab if role is finance
             (await getRole()) === 'finance' && (
               <NavigationItem
-                title="Pending"
-                href="/pending"
-                icon={<ListStart className="h-6 w-6 group-hover:text-white" />}
+                title="Billing Statements"
+                href="/billing-statements"
+                icon={<Book className="h-6 w-6 group-hover:text-white" />}
               />
             )
           }


### PR DESCRIPTION
### TL;DR

Added billing statements functionality with pending accounts management.

### What changed?

- Created new components for billing statements, including a data table, columns definition, and update form.
- Implemented pending accounts management with disabled and editable inputs.
- Added a new navigation item for billing statements.
- Created schemas and form validation for pending accounts.
- Integrated with Supabase for data fetching and mutations.

### How to test?

1. Log in as a user with the 'finance' role.
2. Navigate to the new "Billing Statements" page.
3. Verify that the pending accounts table loads correctly.
4. Try updating a pending account by clicking on a row and filling out the form.
5. Confirm that the update is successful and reflected in the table.

### Why make this change?

This change introduces a new feature for managing billing statements and pending accounts, specifically tailored for users with the finance role. It allows for better organization and handling of financial data within the application, improving the overall workflow for finance-related tasks.