### PR TITLE
TIM-449 fix(billing-statements): allow undefined values to be submitted to form

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/billing-statement-schema.ts
+++ b/src/app/(dashboard)/(home)/billing-statements/billing-statement-schema.ts
@@ -8,39 +8,49 @@ const BillingStatementSchema = z
     or_date: z.date().optional(),
     sa_number: z.string().optional(),
     amount: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
     total_contract_value: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
     balance: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
 
     billing_period: z.preprocess(
-      (val) => parseInt(val as string, 10),
+      (val) =>
+        val === '' || val === undefined
+          ? undefined
+          : parseInt(val as string, 10),
       z.number().int().min(1).max(31).optional(),
     ),
     amount_billed: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
     amount_paid: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
     commission_rate: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
     commission_earned: z.preprocess(
-      (val) => parseFloat(val as string),
+      (val) =>
+        val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
-    account_id: z.string().uuid().optional(),
+    account_id: z.string().uuid(),
   })
   .superRefine((data, ctx) => {
     if (

--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -155,10 +155,16 @@ const BillingStatementModal = <TData,>({
       },
     )
 
+  // only used for edit. it fetches the original data from the database
   useEffect(() => {
     if (originalData) {
       form.reset({
-        ...(originalData as unknown as z.infer<typeof BillingStatementSchema>),
+        ...(Object.fromEntries(
+          Object.entries(originalData).map(([key, value]) => [
+            key,
+            value === null ? undefined : value,
+          ]),
+        ) as unknown as z.infer<typeof BillingStatementSchema>),
         due_date: originalData.due_date
           ? new Date(originalData.due_date)
           : undefined,


### PR DESCRIPTION
### TL;DR

Enhanced input validation and data handling in billing statement functionality.

### What changed?

- Updated `BillingStatementSchema` to handle empty string and undefined values for numeric fields.
- Made `account_id` a required field in the schema.
- Improved data reset logic in `BillingStatementModal` component to handle null values.

### How to test?

1. Open the billing statement form.
2. Try submitting the form with empty fields and verify that validation works correctly.
3. Edit an existing billing statement and ensure that all fields, including those with null values, are properly populated.
4. Attempt to create or edit a billing statement without an `account_id` and confirm that it's not allowed.

### Why make this change?

These changes improve data integrity and user experience by:
1. Preventing unintended conversions of empty strings to zero values.
2. Ensuring that all billing statements are associated with an account.
3. Correctly handling null values when editing existing statements, avoiding potential data loss or misrepresentation.