### PR TITLE
TIM-457 Fetch billing statement inputs

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/billing-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/billing-information.tsx
@@ -1,59 +1,88 @@
-import React from 'react'
+import React, { FC } from 'react'
+import { createBrowserClient } from '@/utils/supabase'
+import getBillingStatementInputs from '@/queries/get-billing-statement-inputs'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { Tables } from '@/types/database.types'
+import getTypes from '@/queries/get-types'
+import { format } from 'date-fns'
+import getBillingStatements from '@/queries/get-billing-statements'
 
-const BillingInformation = () => {
+interface Props {
+  data: Tables<'billing_statements'>
+}
+
+const BillingInformation: FC<Props> = ({ data }) => {
   return (
     <>
       <div className="col-span-3 flex grid-cols-12 flex-col pt-4 lg:grid lg:p-2">
         <div className="flex flex-col gap-2 lg:col-span-3">
-          <span className="text-md font-semibold text-[#161a1d]">Fixed</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.mode_of_payment_id || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
-            MODE OF PREMIUM
+            MODE OF PAYMENT
           </span>
           <span className="text-md font-semibold text-[#161a1d]">
-            10/20/2024
+            {format(new Date(data?.due_date || 'N/A'), 'MMMM d, yyyy')}
           </span>
           <span className="text-sm font-medium text-[#64748b]">DUE DATE</span>
           <span className="text-md font-semibold text-[#161a1d]">
-            123456789
+            {data.or_number || 'N/A'}
           </span>
           <span className="text-sm font-medium text-[#64748b]">OR NUMBER</span>
           <span className="text-md font-semibold text-[#161a1d]">
-            10/10/2024
+            {format(new Date(data?.or_date || 'N/A'), 'MMMM d, yyyy')}
           </span>
           <span className="text-sm font-medium text-[#64748b]">OR DATE</span>
           <span className="text-md font-semibold text-[#161a1d]">
-            123456789
+            {data.sa_number || 'N/A'}
           </span>
           <span className="text-sm font-medium text-[#64748b]">SA NUMBER</span>
         </div>
         <div className="flex flex-col gap-2 lg:col-span-3">
-          <span className="text-md font-semibold text-[#161a1d]">1000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.amount || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">AMOUNT</span>
-          <span className="text-md font-semibold text-[#161a1d]">100000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.total_contract_value || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             TOTAL CONTRACT VALUE
           </span>
-          <span className="text-md font-semibold text-[#161a1d]">100000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.balance || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">BALANCE</span>
-          <span className="text-md font-semibold text-[#161a1d]">30</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.billing_period || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             BILLING PERIOD
           </span>
-          <span className="text-md font-semibold text-[#161a1d]">1000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.amount_billed || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             AMOUNT BILLED
           </span>
         </div>
         <div className="flex flex-col gap-2 lg:col-span-3">
-          <span className="text-md font-semibold text-[#161a1d]">100000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.amount_paid || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             AMOUNT PAID
           </span>
-          <span className="text-md font-semibold text-[#161a1d]">100000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.commission_rate || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             COMMISSION RATE
           </span>
-          <span className="text-md font-semibold text-[#161a1d]">100000</span>
+          <span className="text-md font-semibold text-[#161a1d]">
+            {data.commission_earned || 'N/A'}
+          </span>
           <span className="text-sm font-medium text-[#64748b]">
             COMMISSION EARNED
           </span>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/billing-statements.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/billing-statements.tsx
@@ -1,49 +1,68 @@
-import React from 'react'
+import React, { FC } from 'react'
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Button } from '@/components/ui/button'
-import EmployeesInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/employees-information'
-import { Tables } from '@/types/database.types'
 import { ChevronsUpDown } from 'lucide-react'
 import BillingInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/billing-information'
+import getBillingStatementInputs from '@/queries/get-billing-statement-inputs'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { createBrowserClient } from '@/utils/supabase'
+import EmployeesInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/employees-information'
+import { Tables } from '@/types/database.types'
+import { format } from 'date-fns'
 
-const BillingStatements = () => {
+interface Props {
+  companyId: string
+}
+
+const BillingStatements: FC<Props> = ({ companyId }) => {
+  const supabase = createBrowserClient()
+  const { data: billing, isPending } = useQuery(
+    getBillingStatementInputs(supabase, companyId),
+  )
   return (
     <div className="mx-auto flex w-full flex-col items-center justify-between gap-6">
-      {/*{isPending &&*/}
-      {/*  [1, 2, 3].map((i) => (*/}
-      {/*    <Collapsible*/}
-      {/*      key={i}*/}
-      {/*      className={*/}
-      {/*        'mx-auto w-full rounded-2xl border border-slate-200 bg-background p-6 drop-shadow-md'*/}
-      {/*      }*/}
-      {/*    ></Collapsible>*/}
-      {/*  ))}*/}
-      <Collapsible
-        className={
-          'mx-auto w-full rounded-2xl border border-slate-200 bg-background p-6 drop-shadow-md'
-        }
-      >
-        <CollapsibleTrigger asChild={true}>
-          <Button
-            variant="ghost"
-            className="w-full max-w-5xl items-center justify-between p-0 hover:bg-transparent "
+      {isPending &&
+        [1, 2, 3].map((i) => (
+          <Collapsible
+            key={i}
+            className={
+              'mx-auto w-full rounded-2xl border border-slate-200 bg-background p-6 drop-shadow-md'
+            }
+          ></Collapsible>
+        ))}
+      {billing &&
+        billing.map((billing) => (
+          <Collapsible
+            key={billing.id}
+            className={
+              'mx-auto w-full rounded-2xl border border-slate-200 bg-background p-6 drop-shadow-md'
+            }
           >
-            <span className="text-lg font-semibold capitalize">
-              Billing Statement 1 (date)
-            </span>
-            <ChevronsUpDown className="justify-end" />
-          </Button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="grid-cols-3 lg:grid">
-            <BillingInformation />
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+            <CollapsibleTrigger asChild={true}>
+              <Button
+                variant="ghost"
+                className="w-full max-w-5xl items-center justify-between p-0 hover:bg-transparent "
+              >
+                <span className="text-lg font-semibold capitalize">
+                  Billing Statement -{' '}
+                  {format(new Date(billing?.created_at), 'MMMM d, yyyy')}
+                </span>
+                <ChevronsUpDown className="justify-end" />
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="grid-cols-3 lg:grid">
+                <BillingInformation
+                  data={billing as Tables<'billing_statements'>}
+                />
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        ))}
     </div>
   )
 }

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-page.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-page.tsx
@@ -54,7 +54,7 @@ const CompanyPage: FC<Props> = ({ companyId, role }) => {
           <div className="ml-auto flex w-full flex-col pb-4 lg:items-end lg:justify-center">
             <AddBillingStatementButton />
           </div>
-          <BillingStatements />
+          <BillingStatements companyId={companyId} />
         </TabsContent>
       </div>
     </Tabs>

--- a/src/queries/get-billing-statement-inputs.ts
+++ b/src/queries/get-billing-statement-inputs.ts
@@ -7,7 +7,7 @@ const getBillingStatementInputs = (
   return supabase
     .from('billing_statements')
     .select(
-      'id, mode_of_premium_id, due_date, or_number, or_date, sa_number, amount, total_contract_value, balance, billing_period, is_active, amount_billed, amount_paid, commission_rate, commission_earned',
+      'id, mode_of_payment_id, due_date, or_number, or_date, sa_number, amount, total_contract_value, balance, billing_period, is_active, amount_billed, amount_paid, commission_rate, commission_earned, created_at',
     )
     .eq('account_id', id)
     .order('created_at', { ascending: false })


### PR DESCRIPTION
will change mode of payment tomorrow mwa

### TL;DR

Enhanced billing information display and functionality for personnel accounts.

### What changed?

- Updated `BillingInformation` component to dynamically display data from the `billing_statements` table.
- Modified `BillingStatements` component to fetch and display multiple billing statements for a company.
- Added date formatting for better readability.
- Updated `CompanyPage` to pass `companyId` to `BillingStatements`.
- Adjusted `getBillingStatementInputs` query to include `created_at` and rename `mode_of_premium_id` to `mode_of_payment_id`.

### How to test?

1. Navigate to a personnel account page.
2. Check the "Billing Statements" tab.
3. Verify that multiple billing statements are displayed with correct dates.
4. Expand a billing statement and confirm that all fields are populated with accurate data.
5. Ensure that dates are formatted correctly (e.g., "October 20, 2024").

### Why make this change?

This change improves the display and management of billing information for personnel accounts. It provides a more comprehensive and dynamic view of billing statements, allowing for better tracking and management of financial data within the system.