### PR TITLE
TIM-459 REFACTOR(employees): allow all roles to insert/edit company-employees

### DIFF
--- a/supabase/migrations/20241020235146_update_company_employees_rls.sql
+++ b/supabase/migrations/20241020235146_update_company_employees_rls.sql
@@ -1,0 +1,47 @@
+-- Drop the existing policy for updating company employees
+drop policy if exists "underwriting can update company employees" on company_employees;
+
+-- Create a new policy for updating company employees
+create policy "all departments can update company employees except agent"
+on company_employees
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from user_profiles
+    where user_profiles.user_id = auth.uid() 
+    and user_profiles.department_id in (
+      select id from departments where name in ('marketing', 'after-sales', 'under-writing', 'finance', 'admin')
+    )
+  )
+)
+with check (
+  exists (
+    select 1
+    from user_profiles
+    where user_profiles.user_id = auth.uid() 
+    and user_profiles.department_id in (
+      select id from departments where name in ('marketing', 'after-sales', 'under-writing', 'finance', 'admin')
+    )
+  )
+);
+
+-- Drop the existing policy for inserting company employees
+drop policy if exists "underwriting can insert company employees" on company_employees;
+
+-- Create a new policy for inserting company employees
+create policy "all departments can insert company employees except agent"
+on company_employees
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from user_profiles
+    where user_profiles.user_id = auth.uid() 
+    and user_profiles.department_id in (
+      select id from departments where name in ('marketing', 'after-sales', 'under-writing', 'finance', 'admin')
+    )
+  )
+);


### PR DESCRIPTION
### TL;DR

Updated row-level security policies for company employees table to allow access for multiple departments.

### What changed?

- Dropped existing policies for updating and inserting company employees.
- Created new policies allowing all departments except 'agent' to update and insert company employees.
- Departments with access now include marketing, after-sales, under-writing, finance, and admin.

### How to test?

1. Log in as users from different departments (marketing, after-sales, under-writing, finance, admin, and agent).
2. Attempt to update and insert records in the company_employees table.
3. Verify that users from all departments except 'agent' can perform these operations.
4. Confirm that users from the 'agent' department cannot update or insert records.

### Why make this change?

This change expands access to the company_employees table beyond just the underwriting department. It allows for more efficient collaboration and data management across multiple departments while still maintaining security by excluding the 'agent' department from these operations.