### PR TITLE
TIM-462 feat(employees): add edit employees function

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal.tsx
@@ -2,7 +2,6 @@
 
 import EmployeeForm from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-provider'
-import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -11,10 +10,18 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Plus } from 'lucide-react'
-import { useState } from 'react'
+import { Tables } from '@/types/database.types'
+import { FC, ReactNode, useState } from 'react'
 
-const AddEmployeeModal = () => {
+interface AddEmployeeModalProps {
+  oldEmployeeData?: Tables<'company_employees'>
+  button: ReactNode
+}
+
+const EmployeeFormModal: FC<AddEmployeeModalProps> = ({
+  oldEmployeeData,
+  button,
+}) => {
   const { userRole } = useCompanyContext()
   const [isOpen, setIsOpen] = useState(false)
 
@@ -29,23 +36,25 @@ const AddEmployeeModal = () => {
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild={true}>
-        <Button className="gap-2 rounded-md">
-          <Plus /> <span> Add Employee </span>
-        </Button>
-      </DialogTrigger>
+      <DialogTrigger asChild={true}>{button}</DialogTrigger>
       <DialogContent className="max-w-6xl">
         <DialogHeader>
-          <DialogTitle>Add Employee</DialogTitle>
+          <DialogTitle>
+            {oldEmployeeData ? 'Edit Employee' : 'Add Employee'}
+          </DialogTitle>
         </DialogHeader>
-        <DialogDescription>Add a new employee to the company</DialogDescription>
+        <DialogDescription>
+          {oldEmployeeData
+            ? 'Edit the employee details'
+            : 'Add a new employee to the company'}
+        </DialogDescription>
 
         {/* Employee Form */}
-        <EmployeeForm setIsOpen={setIsOpen} />
+        <EmployeeForm setIsOpen={setIsOpen} oldEmployeeData={oldEmployeeData} />
         {/* End of Employee Form */}
       </DialogContent>
     </Dialog>
   )
 }
 
-export default AddEmployeeModal
+export default EmployeeFormModal

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-columns.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-columns.tsx
@@ -1,7 +1,18 @@
+import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal'
 import TableHeader from '@/components/table-header'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
 import { format } from 'date-fns'
+import { MoreHorizontal, Pencil } from 'lucide-react'
 
 const employeesColumns: ColumnDef<Tables<'company_employees'>>[] = [
   // company name is not needed since we are already in the company page
@@ -47,34 +58,45 @@ const employeesColumns: ColumnDef<Tables<'company_employees'>>[] = [
       return format(new Date(row.getValue('effective_date')), 'PP')
     },
   },
-  // {
-  //   id: 'actions',
-  //   cell: ({ row }) => {
-  //     const employee = row.original
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      const employee = row.original
 
-  //     return (
-  //       <DropdownMenu>
-  //         <DropdownMenuTrigger asChild>
-  //           <Button variant="ghost" className="h-8 w-8 p-0">
-  //             <span className="sr-only">Open menu</span>
-  //             <MoreHorizontal className="h-4 w-4" />
-  //           </Button>
-  //         </DropdownMenuTrigger>
-  //         <DropdownMenuContent align="end">
-  //           <DropdownMenuLabel>Actions</DropdownMenuLabel>
-  //           <DropdownMenuItem
-  //             onClick={() => navigator.clipboard.writeText(employee.id)}
-  //           >
-  //             Copy payment ID
-  //           </DropdownMenuItem>
-  //           <DropdownMenuSeparator />
-  //           <DropdownMenuItem>View customer</DropdownMenuItem>
-  //           <DropdownMenuItem>View payment details</DropdownMenuItem>
-  //         </DropdownMenuContent>
-  //       </DropdownMenu>
-  //     )
-  //   }
-  // }
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Open menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <EmployeeFormModal
+              oldEmployeeData={employee}
+              button={
+                <DropdownMenuItem
+                  onSelect={(e) => e.preventDefault()}
+                  className="cursor-pointer"
+                >
+                  <Pencil className="mr-2 h-4 w-4" /> Edit
+                </DropdownMenuItem>
+              }
+            />
+            {/* <DropdownMenuItem
+              onClick={() => navigator.clipboard.writeText(employee.id)}
+            >
+              <Pencil className="h-4 w-4 mr-2" /> Edit
+            </DropdownMenuItem> */}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>View customer</DropdownMenuItem>
+            <DropdownMenuItem>View payment details</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )
+    },
+  },
 ]
 
 export default employeesColumns

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
@@ -1,5 +1,6 @@
-import AddEmployeeModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/add-employee-modal'
+import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal'
 import TablePagination from '@/components/table-pagination'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
   Table,
@@ -21,6 +22,7 @@ import {
   useReactTable,
   VisibilityState,
 } from '@tanstack/react-table'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
 interface DataTableProps<TData, TValue> {
@@ -66,7 +68,13 @@ const EmployeesDataTable = <TData, TValue>({
           }
           className="max-w-sm"
         />
-        <AddEmployeeModal />
+        <EmployeeFormModal
+          button={
+            <Button className="gap-2 rounded-md">
+              <Plus /> <span> Add Employee </span>
+            </Button>
+          }
+        />
       </div>
       <div className="rounded-md border">
         <Table>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-provider.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-provider.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { Tables } from '@/types/database.types'
 import { createContext, ReactNode, useContext, useState } from 'react'
 
 const useCompanyContext = () => {
@@ -9,29 +10,37 @@ const useCompanyContext = () => {
   return context
 }
 
-const CompanyContext = createContext({
-  showAddPersonnel: false,
-  setShowAddPersonnel: (_value: boolean) => {},
+const CompanyContext = createContext<{
+  userRole: string
+  setUserRole: (value: string) => void
+  accountId: string
+  setAccountId: (value: string) => void
+  oldEmployeeData: Tables<'company_employees'> | null
+  setOldEmployeeData: (value: Tables<'company_employees'> | null) => void
+}>({
   userRole: '',
-  setUserRole: (_value: string) => {},
+  setUserRole: () => {},
   accountId: '',
-  setAccountId: (_value: string) => {},
+  setAccountId: () => {},
+  oldEmployeeData: null,
+  setOldEmployeeData: () => {},
 })
 
 const CompanyProvider = ({ children }: { children: ReactNode }) => {
-  const [showAddPersonnel, setShowAddPersonnel] = useState(false)
   const [userRole, setUserRole] = useState<string>('')
   const [accountId, setAccountId] = useState<string>('')
+  const [oldEmployeeData, setOldEmployeeData] =
+    useState<Tables<'company_employees'> | null>(null)
 
   return (
     <CompanyContext.Provider
       value={{
-        showAddPersonnel,
-        setShowAddPersonnel,
         userRole,
         setUserRole,
         accountId,
         setAccountId,
+        oldEmployeeData,
+        setOldEmployeeData,
       }}
     >
       {children}


### PR DESCRIPTION
### TL;DR

Refactored employee management functionality to support both adding and editing employees.

### What changed?

- Renamed `AddEmployeeModal` to `EmployeeFormModal` and updated it to handle both adding and editing employees.
- Enhanced `EmployeeForm` to pre-populate fields when editing an existing employee.
- Updated `employeesColumns` to include an edit action in the dropdown menu.
- Modified `EmployeesDataTable` to use the new `EmployeeFormModal` component.
- Updated `CompanyProvider` to include state for managing the currently edited employee data.

### How to test?

1. Navigate to the employees page for a company.
2. Try adding a new employee using the "Add Employee" button.
3. Verify that the new employee appears in the table.
4. Click the dropdown menu for an existing employee and select "Edit".
5. Confirm that the edit modal opens with pre-populated data.
6. Make changes and submit the form to update the employee information.
7. Verify that the changes are reflected in the table.

### Why make this change?

This change improves the user experience by allowing administrators to edit existing employee information directly from the employee list. It also consolidates the logic for adding and editing employees into a single reusable component, improving code maintainability and reducing duplication.