### PR TITLE
feat(billing): grant admin access to billing statements and RLS

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/page.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/page.tsx
@@ -18,7 +18,7 @@ const BillingStatementsPage = async () => {
   const queryClient = new QueryClient()
   await prefetchQuery(queryClient, getBillingStatements(supabase))
 
-  await pageProtect('finance')
+  await pageProtect(['finance', 'admin'])
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(dashboard)/admin/layout.tsx
+++ b/src/app/(dashboard)/admin/layout.tsx
@@ -3,7 +3,7 @@ import pageProtect from '@/utils/page-protect'
 import { ReactNode } from 'react'
 
 const AdminLayout = async ({ children }: { children: ReactNode }) => {
-  await pageProtect('admin')
+  await pageProtect(['admin'])
   return <>{children}</>
 }
 

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -6,6 +6,7 @@ import AdminNavigation from './admin-navigation'
 import NavigationItem from './navigation-item'
 
 const Navigation = async () => {
+  const role = await getRole()
   return (
     <div className="space-y-6 px-3">
       <div>
@@ -39,7 +40,7 @@ const Navigation = async () => {
           />
           {
             // only show pending tab if role is finance
-            (await getRole()) === 'finance' && (
+            role && ['finance', 'admin'].includes(role) && (
               <NavigationItem
                 title="Billing Statements"
                 href="/billing-statements"

--- a/src/utils/page-protect.ts
+++ b/src/utils/page-protect.ts
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers'
 import { createServerClient } from './supabase'
 import { redirect } from 'next/navigation'
 
-const pageProtect = async (department: string) => {
+const pageProtect = async (departments: string[]) => {
   const supabase = createServerClient(cookies())
 
   const {
@@ -22,7 +22,7 @@ const pageProtect = async (department: string) => {
   }
 
   // @ts-ignore
-  if ((userProfileData.departments.name as any) !== department) {
+  if (!departments.includes(userProfileData.departments.name as any)) {
     return redirect('/')
   }
 }

--- a/supabase/migrations/20241023134424_admin_to_billing_statments_rls.sql
+++ b/supabase/migrations/20241023134424_admin_to_billing_statments_rls.sql
@@ -1,0 +1,88 @@
+alter table billing_statements enable row level security;
+
+drop policy if exists "finance department users to read billing_statements" on billing_statements;
+
+drop policy if exists "finance department users to insert billing_statements" on billing_statements;
+
+drop policy if exists "finance department users to update billing_statements" on billing_statements;
+
+create policy "admin and finance department users to read billing_statements" on billing_statements for
+select
+  to authenticated using (
+    exists (
+      select
+        1
+      from
+        user_profiles
+      where
+        user_profiles.user_id = auth.uid ()
+        and user_profiles.department_id in (
+          select
+            id
+          from
+            departments
+          where
+            name in ('admin', 'finance')
+        )
+    )
+  );
+
+create policy "admin and finance department users to insert billing_statements" on billing_statements for insert to authenticated
+with
+  check (
+    exists (
+      select
+        1
+      from
+        user_profiles
+      where
+        user_profiles.user_id = auth.uid ()
+        and user_profiles.department_id in (
+          select
+            id
+          from
+            departments
+          where
+            name in ('admin', 'finance')
+        )
+    )
+  );
+
+create policy "admin and finance department users to update billing_statements" on billing_statements for
+update to authenticated using (
+  exists (
+    select
+      1
+    from
+      user_profiles
+    where
+      user_profiles.user_id = auth.uid ()
+      and user_profiles.department_id in (
+        select
+          id
+        from
+          departments
+        where
+          name in ('admin', 'finance')
+      )
+  )
+)
+with
+  check (
+    exists (
+      select
+        1
+      from
+        user_profiles
+      where
+        user_profiles.user_id = auth.uid ()
+        and user_profiles.department_id in (
+          select
+            id
+          from
+            departments
+          where
+            name in ('admin', 'finance')
+        )
+    )
+  );


### PR DESCRIPTION
### TL;DR

Extended billing statement access and management to admin users.

### What changed?

- Modified `pageProtect` function to accept an array of departments instead of a single department.
- Updated `BillingStatementsPage` and `AdminLayout` to use the new `pageProtect` function signature.
- Adjusted the Navigation component to show the Billing Statements tab for both finance and admin roles.
- Added new SQL migration to update row-level security policies for the `billing_statements` table, allowing admin users to read, insert, and update billing statements alongside finance users.

### How to test?

1. Log in as an admin user.
2. Verify that the Billing Statements tab is visible in the navigation.
3. Access the Billing Statements page and ensure it loads without redirecting.
4. Attempt to read, insert, and update billing statements as an admin user.
5. Confirm that finance users still have access to billing statements.
6. Check that users from other departments cannot access billing statements.

### Why make this change?

This change extends billing statement management capabilities to admin users, allowing them to oversee and manage financial data alongside the finance department. This improves administrative control and provides more flexibility in managing billing-related tasks within the application.