### PR TITLE
TIM-456 feat(accounts): add role check on accounts page

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/page.tsx
+++ b/src/app/(dashboard)/(home)/accounts/page.tsx
@@ -10,11 +10,20 @@ import {
 } from '@tanstack/react-query'
 import { cookies } from 'next/headers'
 import AccountsTable from './accounts-table'
+import pageProtect from '@/utils/page-protect'
 
 const AccountsPage = async () => {
   const supabase = createServerClient(cookies())
   const queryClient = new QueryClient()
   await prefetchQuery(queryClient, getAccounts(supabase))
+
+  await pageProtect([
+    'marketing',
+    'after-sales',
+    'under-writing',
+    'finance',
+    'admin',
+  ])
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>


### PR DESCRIPTION
### TL;DR

Added page protection to the Accounts page.

### What changed?

- Imported the `pageProtect` function from `@/utils/page-protect`.
- Implemented `pageProtect` with an array of allowed roles: 'marketing', 'after-sales', 'under-writing', 'finance', and 'admin'.

### How to test?

1. Log in with different user roles.
2. Attempt to access the Accounts page.
3. Verify that only users with the specified roles can view the page.
4. Ensure users without the allowed roles are redirected or shown an appropriate error message.

### Why make this change?

To enhance security and access control for the Accounts page, ensuring that only authorized personnel with specific roles can view sensitive account information.