### PR TITLE
fix(accounts): remove form reset after company update

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -79,10 +79,7 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
     'id',
     {
       onSuccess: () => {
-        form.reset()
-
         setEditMode(false)
-        // queryClient.invalidateQueries({queryKey: ['id', companyId]})
       },
       onError: (error) => {
         toast({


### PR DESCRIPTION
### TL;DR
Removed form reset after company about section update

### What changed?
Removed the `form.reset()` call and an unused commented-out query invalidation in the success handler of the company about section

### How to test?
1. Navigate to a company's about section
2. Edit and save the form
3. Verify that the form remains populated with the updated values after saving

### Why make this change?
Resetting the form after a successful update was clearing the displayed values, creating a confusing user experience where the updated information would momentarily disappear before being re-fetched and displayed