### PR TITLE
fix(accounts): handle null HMO and account type values

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
@@ -286,23 +286,41 @@ const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
         <div className="grid grid-cols-2 gap-2 pt-4">
           <CompanyInformationItem
             label={'HMO Provider'}
-            value={(account?.hmo_provider as any).name}
+            value={
+              account?.hmo_provider ? (account.hmo_provider as any).name : ''
+            }
           />
           <CompanyInformationItem
             label={'Previous HMO Provider'}
-            value={(account?.previous_hmo_provider as any).name}
+            value={
+              account?.previous_hmo_provider
+                ? (account.previous_hmo_provider as any).name
+                : ''
+            }
           />
           <CompanyInformationItem
             label={'Current HMO Provider'}
-            value={(account?.current_hmo_provider as any).name}
+            value={
+              account?.current_hmo_provider
+                ? (account.current_hmo_provider as any).name
+                : ''
+            }
           />
           <CompanyInformationItem
             label={'Principal Plan Type'}
-            value={(account?.principal_plan_type as any).name}
+            value={
+              account?.principal_plan_type
+                ? (account.principal_plan_type as any).name
+                : ''
+            }
           />
           <CompanyInformationItem
             label={'Dependent Plan Type'}
-            value={(account?.dependent_plan_type as any).name}
+            value={
+              account?.dependent_plan_type
+                ? (account.dependent_plan_type as any).name
+                : ''
+            }
           />
           <CompanyInformationItem
             label={'Total Utilization'}

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
@@ -148,7 +148,9 @@ const CompanyAccountInformation: FC<CompanyAccountInformationProps> = ({
         <div className="grid grid-cols-2 gap-2 pt-4 lg:grid-cols-1">
           <CompanyInformationItem
             label="Account Type"
-            value={(account?.account_type as any).name}
+            value={
+              account?.account_type ? (account.account_type as any).name : ''
+            }
           />
           <CompanyInformationItem
             label="Agent"

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -482,7 +482,11 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
           />
           <CompanyInformationItem
             label={'Mode of Payment'}
-            value={(account?.mode_of_payment as any).name}
+            value={
+              account?.mode_of_payment
+                ? (account.mode_of_payment as any).name
+                : ''
+            }
           />
           <CompanyInformationItem
             label={'Expiration Date'}


### PR DESCRIPTION
### TL;DR
Added null checks for company profile information fields to prevent rendering errors

### What changed?
Added conditional checks before accessing nested object properties in company profile components. This includes checks for:
- HMO Provider details
- Account Type information
- Mode of Payment data
- Plan Type information
- Previous and Current HMO Provider details

### How to test?
1. Navigate to a company profile page
2. Verify that fields display empty strings when their corresponding data is null
3. Confirm that fields still display correctly when data is present
4. Test with accounts that have missing or incomplete information

### Why make this change?
Prevents potential runtime errors when accessing properties of undefined objects, improving the application's stability and error handling. This is particularly important when dealing with incomplete or partially loaded company profile data.