### PR TITLE
fix(employees): change maximum benefit limit to string type

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema.ts
@@ -9,9 +9,7 @@ const employeeSchema = z.object({
   card_number: z.string().optional(),
   effective_date: z.date().optional(),
   room_plan: z.string().optional(),
-  maximum_benefit_limit: z
-    .preprocess((val) => parseFloat(val as string), z.number())
-    .optional(),
+  maximum_benefit_limit: z.string().optional(),
 })
 
 export default employeeSchema

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -251,15 +251,7 @@ export type Database = {
           updated_at?: string | null
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: 'accounts_column_visibility_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: true
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
+        Relationships: []
       }
       activity_logs: {
         Row: {
@@ -289,15 +281,7 @@ export type Database = {
           updated_at?: string
           user_id?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: 'activity_logs_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
+        Relationships: []
       }
       billing_statements: {
         Row: {
@@ -391,7 +375,7 @@ export type Database = {
           id: string
           is_active: boolean
           last_name: string | null
-          maximum_benefit_limit: number | null
+          maximum_benefit_limit: string | null
           room_plan: string | null
           updated_at: string
         }
@@ -408,7 +392,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           last_name?: string | null
-          maximum_benefit_limit?: number | null
+          maximum_benefit_limit?: string | null
           room_plan?: string | null
           updated_at?: string
         }
@@ -425,7 +409,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           last_name?: string | null
-          maximum_benefit_limit?: number | null
+          maximum_benefit_limit?: string | null
           room_plan?: string | null
           updated_at?: string
         }
@@ -435,13 +419,6 @@ export type Database = {
             columns: ['account_id']
             isOneToOne: false
             referencedRelation: 'accounts'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'company_employees_created_by_fkey'
-            columns: ['created_by']
-            isOneToOne: false
-            referencedRelation: 'users'
             referencedColumns: ['id']
           },
         ]
@@ -549,15 +526,7 @@ export type Database = {
           title?: string
           user_id?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: 'notifications_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: false
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
-        ]
+        Relationships: []
       }
       plan_types: {
         Row: {
@@ -614,13 +583,6 @@ export type Database = {
             columns: ['department_id']
             isOneToOne: false
             referencedRelation: 'departments'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'user_profiles_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: true
-            referencedRelation: 'users'
             referencedColumns: ['id']
           },
         ]
@@ -841,4 +803,19 @@ export type Enums<
   ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
     ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema['CompositeTypes']
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
+    ? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never

--- a/supabase/migrations/20241024083102_change_maximum_benefit_limit_data_type.sql
+++ b/supabase/migrations/20241024083102_change_maximum_benefit_limit_data_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE company_employees
+ALTER COLUMN maximum_benefit_limit TYPE varchar(255) USING maximum_benefit_limit::varchar;


### PR DESCRIPTION
### TL;DR
Changed the `maximum_benefit_limit` field from number to string type in the company employees table.

### What changed?
- Modified the `maximum_benefit_limit` column in `company_employees` table to use `varchar(255)` instead of a numeric type
- Updated the employee schema to handle `maximum_benefit_limit` as a string
- Updated database types to reflect the new string type for `maximum_benefit_limit`
- Removed unused database relationships

### How to test?
1. Run the migration to update the database schema
2. Verify that employee forms accept string values for maximum benefit limit
3. Confirm existing employee records display correctly with the new data type
4. Test creating and updating employees with various benefit limit values

### Why make this change?
To accommodate benefit limits that may include special characters, currency symbols, or formatted numbers, providing more flexibility in how benefit limits can be represented and displayed in the system.