### PR TITLE
TIM-493 fix(company): edit input build errors

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
@@ -239,7 +239,12 @@ const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
                   <div className="flex flex-row pt-4">
                     <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
                       Total Premium Paid:
-                      <Input className="w-full" {...field} type="number" />
+                      <Input
+                        className="w-full"
+                        {...field}
+                        type="number"
+                        value={field.value?.toString()}
+                      />
                     </div>
                   </div>
                 </FormControl>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -75,7 +75,12 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
                 <div className="flex flex-row pt-4">
                   <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
                     Initial Contract Value:
-                    <Input className="w-full" {...field} type="number" />
+                    <Input
+                      className="w-full"
+                      {...field}
+                      type="number"
+                      value={field.value?.toString()}
+                    />
                   </div>
                 </div>
                 <FormMessage />
@@ -91,7 +96,12 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
                   <div className="flex flex-row pt-4">
                     <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
                       Initial Head Count:
-                      <Input className="w-full" {...field} type="number" />
+                      <Input
+                        className="w-full"
+                        {...field}
+                        type="number"
+                        value={field.value?.toString()}
+                      />
                     </div>
                   </div>
                 </FormControl>


### PR DESCRIPTION
### TL;DR

Updated Input components to handle number values correctly in company profile forms.

### What changed?

- Modified the `Input` components in `company-HMO-information.tsx` and `company-contract-information.tsx` files.
- Added `value={field.value?.toString()}` to ensure proper rendering of number values in the input fields.

### How to test?

1. Navigate to the company profile pages containing HMO information and contract information.
2. Enter numeric values in the "Total Premium Paid", "Initial Contract Value", and "Initial Head Count" fields.
3. Verify that the entered values are displayed correctly and can be edited without issues.

### Why make this change?

This change addresses a potential issue where number values might not be properly handled or displayed in the input fields. By explicitly converting the value to a string, we ensure consistent rendering and prevent any unexpected behavior when dealing with numeric inputs.