### PR TITLE
TIM-494 feat(billing-statements): add Delete Billing Statements button on company profile page

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(billing statements)/billing-statements.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(billing statements)/billing-statements.tsx
@@ -1,6 +1,8 @@
 import BillingInformation, {
   BillingInfoProps,
 } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(billing statements)/billing-information'
+import DeleteBillingStatement from '@/components/billing-statement/delete-billing-statement'
+
 import { Button } from '@/components/ui/button'
 import {
   Collapsible,
@@ -56,10 +58,13 @@ const BillingStatements: FC<Props> = ({ companyId }) => {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div className="grid-cols-3 lg:grid">
+              <div className="flex flex-col gap-4 lg:flex-row">
                 <BillingInformation
                   data={{ ...billing } as BillingInfoProps['data']}
                 />
+                <div className="flex flex-row items-center justify-end lg:ml-auto lg:items-end">
+                  <DeleteBillingStatement id={billing.id} />
+                </div>
               </div>
             </CollapsibleContent>
           </Collapsible>

--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -245,7 +245,7 @@ const BillingStatementModal = <TData,>({
         account_id: CompanyContext.accountId,
       })
     }
-  }, [CompanyContext])
+  }, [CompanyContext, form])
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -590,7 +590,12 @@ const BillingStatementModal = <TData,>({
                 originalData && '!justify-between',
               )}
             >
-              {originalData && <DeleteBillingStatement id={originalData.id} />}
+              {originalData && (
+                <DeleteBillingStatement
+                  id={originalData.id}
+                  setOpenModalOpen={setOpen}
+                />
+              )}
               <div className="space-x-2">
                 <Button
                   variant="outline"

--- a/src/components/billing-statement/delete-billing-statement.tsx
+++ b/src/components/billing-statement/delete-billing-statement.tsx
@@ -9,11 +9,13 @@ import { FC } from 'react'
 
 interface DeleteBillingStatementProps {
   id: string
+  setOpenModalOpen?: (open: boolean) => void
 }
 
 const DeleteBillingStatement: FC<DeleteBillingStatementProps> = ({
   id,
-}: DeleteBillingStatementProps) => {
+  setOpenModalOpen,
+}) => {
   const { openConfirmation } = useConfirmationStore()
   const { toast } = useToast()
 
@@ -27,10 +29,14 @@ const DeleteBillingStatement: FC<DeleteBillingStatementProps> = ({
       onSuccess: () => {
         toast({
           variant: 'default',
-          title: 'Success',
-          description: 'Account deleted',
+          title: 'Billing Statement Deleted',
+          description: 'The billing statement has been successfully deleted.',
         })
-        window.location.reload()
+
+        // close modal if setOpenModalOpen is provided
+        if (setOpenModalOpen) {
+          setOpenModalOpen(false)
+        }
       },
       onError: (error) => {
         toast({

--- a/src/queries/get-billing-statement-by-company-id.ts
+++ b/src/queries/get-billing-statement-by-company-id.ts
@@ -10,6 +10,7 @@ const getBillingStatementByCompanyId = (
       'id, mode_of_payments(name, id), due_date, or_number, or_date, sa_number, amount, total_contract_value, balance, billing_period, is_active, amount_billed, amount_paid, commission_rate, commission_earned, created_at',
     )
     .eq('account_id', id)
+    .eq('is_active', true)
     .order('created_at', { ascending: false })
     .throwOnError()
 }


### PR DESCRIPTION
### TL;DR

Added delete functionality for billing statements and improved the UI layout.

### What changed?

- Added a delete button for billing statements in the billing statements list view
- Improved the layout of billing information and delete button in the collapsible content
- Updated the delete billing statement component to optionally close the modal after deletion
- Modified the billing statement query to only fetch active statements
- Added error handling and success messages for the delete operation

### How to test?

1. Navigate to the billing statements page for a company
2. Expand a billing statement and verify the delete button is present
3. Click the delete button and confirm the deletion
4. Check that the billing statement is removed from the list
5. Open a billing statement in the modal and test the delete functionality there as well
6. Verify that only active billing statements are displayed in the list

### Why make this change?

This change improves user experience by allowing easier management of billing statements. Users can now delete statements directly from the list view or the modal, providing more flexibility in managing financial records. The improved layout enhances readability and usability of the billing information section.