### PR TITLE
feat(commission): implement percentage input mask for commission rate

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
@@ -22,6 +22,8 @@ import {
 } from '@/components/ui/select'
 import getTypes from '@/queries/get-types'
 import getAgents from '@/queries/get-agents'
+import { useMaskito } from '@maskito/react'
+import percentageOptions from '@/components/maskito/percentage-options'
 
 const CompanyInformationItem = ({
   label,
@@ -49,6 +51,8 @@ const CompanyAccountInformation: FC<CompanyAccountInformationProps> = ({
   const { data: account } = useQuery(getAccountById(supabase, id))
   const { data: accountType } = useQuery(getTypes(supabase, 'account_types'))
   const { data: agents } = useQuery(getAgents(supabase))
+
+  const maskedPercentageRef = useMaskito({ options: percentageOptions })
 
   return (
     <>
@@ -127,14 +131,17 @@ const CompanyAccountInformation: FC<CompanyAccountInformationProps> = ({
               <FormItem>
                 <FormControl>
                   <div className="flex flex-row pt-4">
-                    <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
+                    <div className="text-md flex w-full flex-row text-[#1e293b] md:grid md:grid-cols-2 lg:grid-cols-1">
                       Commission Rate:
                       <Input
                         className="w-full"
                         {...field}
-                        type="number"
-                        min="0"
-                        step="0.01"
+                        type="text"
+                        ref={maskedPercentageRef}
+                        onInput={(e) =>
+                          // @ts-ignore
+                          form.setValue(field.name, e.target.value)
+                        }
                       />
                     </div>
                   </div>

--- a/src/app/(dashboard)/(home)/accounts/accounts-schema.ts
+++ b/src/app/(dashboard)/(home)/accounts/accounts-schema.ts
@@ -41,7 +41,7 @@ const accountsSchema = z.object({
   annual_physical_examination_date: z.date().nullable(),
   commision_rate: z.preprocess(
     (val) => (val === null || val === '' ? null : parseFloat(val as string)),
-    z.number().nonnegative().nullable(),
+    z.number().min(0).max(100).nullable(),
   ),
   additional_benefits: z.string().nullable(),
   special_benefits: z.string().nullable(),

--- a/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
+++ b/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
@@ -1,3 +1,4 @@
+import percentageOptions from '@/components/maskito/percentage-options'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -7,7 +8,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form'
-import { Input, InputProps } from '@/components/ui/input'
+import { Input } from '@/components/ui/input'
 import {
   Popover,
   PopoverContent,
@@ -24,13 +25,14 @@ import getAgents from '@/queries/get-agents'
 import getTypes from '@/queries/get-types'
 import { createBrowserClient } from '@/utils/supabase'
 import { cn } from '@/utils/tailwind'
+import { useMaskito } from '@maskito/react'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import { format } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
+import { FC } from 'react'
 import { ControllerRenderProps, useFormContext } from 'react-hook-form'
 import { z } from 'zod'
 import accountsSchema from '../accounts-schema'
-import { FC } from 'react'
 
 interface Props {
   isLoading: boolean
@@ -55,6 +57,8 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
     const value = e.target.value === '' ? null : e.target.value
     field.onChange(value)
   }
+
+  const maskedPercentageRef = useMaskito({ options: percentageOptions })
 
   return (
     <>
@@ -268,8 +272,8 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
                   {...field}
                   type="number"
                   value={field.value ?? ''}
-                  onChange={(e) => handleInputChange(field, e)}
                   disabled={isLoading}
+                  onChange={(e) => handleInputChange(field, e)}
                 />
               </FormControl>
               <FormMessage />
@@ -768,12 +772,12 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
               <FormControl>
                 <Input
                   {...field}
-                  type="number"
-                  min="0"
-                  step="0.01"
+                  type="text"
                   placeholder="Enter commission rate"
                   value={field.value ?? ''}
-                  onChange={(e) => handleInputChange(field, e)}
+                  // @ts-ignore
+                  onInput={(e) => form.setValue(field.name, e.target.value)}
+                  ref={maskedPercentageRef}
                 />
               </FormControl>
               <FormMessage />

--- a/src/components/maskito/percentage-options.ts
+++ b/src/components/maskito/percentage-options.ts
@@ -1,0 +1,29 @@
+import type { MaskitoOptions } from '@maskito/core'
+import { maskitoUpdateElement } from '@maskito/core'
+import {
+  maskitoCaretGuard,
+  maskitoEventHandler,
+  maskitoNumberOptionsGenerator,
+} from '@maskito/kit'
+
+export const postfix = '%'
+const { plugins, ...numberOptions } = maskitoNumberOptionsGenerator({
+  postfix,
+  min: 0,
+  max: 100,
+  precision: 2,
+})
+
+export default {
+  ...numberOptions,
+  plugins: [
+    ...plugins,
+    // Forbids caret to be placed after postfix
+    maskitoCaretGuard((value) => [0, value.length - 1]),
+    maskitoEventHandler('blur', (element) => {
+      if (element.value === postfix) {
+        maskitoUpdateElement(element, `0${postfix}`)
+      }
+    }),
+  ],
+} satisfies MaskitoOptions


### PR DESCRIPTION
### TL;DR

Implemented percentage masking for commission rate inputs and updated validation.

### What changed?

- Added `useMaskito` hook with percentage options for commission rate inputs in both company account information and marketing inputs forms.
- Updated the `commision_rate` field in the accounts schema to enforce a range between 0 and 100.
- Replaced the number input for commission rate with a masked text input.
- Removed unused `dateOptions` from the maskito options file.
- Created a new `percentage-options.ts` file with custom maskito options for percentage inputs.

### How to test?

1. Navigate to the company account information or marketing inputs form.
2. Attempt to enter commission rates:
   - Try entering values between 0% and 100%
   - Attempt to enter values outside this range
   - Check that decimal places are limited to two
   - Verify that the '%' symbol is automatically appended
3. Submit the form and ensure the entered percentage is correctly saved and displayed.

### Why make this change?

This change improves the user experience when entering commission rates by:
- Providing immediate visual feedback with the percentage symbol
- Preventing invalid inputs (e.g., negative percentages or values over 100%)
- Ensuring consistent formatting of percentage values throughout the application
- Reducing the likelihood of data entry errors