### PR TITLE
TIM-511 feat(accounts): add input masking for currencies on "create new account"

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/accounts-schema.ts
+++ b/src/app/(dashboard)/(home)/accounts/accounts-schema.ts
@@ -2,27 +2,28 @@ import { z } from 'zod'
 
 const accountsSchema = z.object({
   is_active: z.boolean().nullable(),
-  agent_id: z.string().nullable(),
-  company_name: z.string().min(1),
-  company_address: z.string().nullable(),
-  nature_of_business: z.string().nullable(),
-  hmo_provider_id: z.string().nullable(),
-  previous_hmo_provider_id: z.string().nullable(),
-  current_hmo_provider_id: z.string().nullable(),
-  account_type_id: z.string().nullable(),
+  agent_id: z.string().uuid().nullable(),
+  company_name: z.string().min(1).max(255),
+  company_address: z.string().max(500).nullable(),
+  nature_of_business: z.string().max(500).nullable(),
+  hmo_provider_id: z.string().uuid().nullable(),
+  previous_hmo_provider_id: z.string().uuid().nullable(),
+  current_hmo_provider_id: z.string().uuid().nullable(),
+  account_type_id: z.string().uuid().nullable(),
   total_utilization: z.preprocess(
     (val) => (val === null || val === '' ? null : parseFloat(val as string)),
     z.number().nullable(),
   ),
-  total_premium_paid: z.preprocess(
-    (val) => (val === null || val === '' ? null : parseFloat(val as string)),
-    z.number().nullable(),
-  ),
-  signatory_designation: z.string().nullable(),
-  contact_person: z.string().nullable(),
-  contact_number: z.string().nullable(),
-  principal_plan_type_id: z.string().nullable(),
-  dependent_plan_type_id: z.string().nullable(),
+  total_premium_paid: z.preprocess((val) => {
+    if (val === null || val === '') return null
+    const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+    return isNaN(parsedVal) ? null : parsedVal
+  }, z.number().nullable()),
+  signatory_designation: z.string().max(255).nullable(),
+  contact_person: z.string().max(255).nullable(),
+  contact_number: z.string().max(255).nullable(),
+  principal_plan_type_id: z.string().uuid().nullable(),
+  dependent_plan_type_id: z.string().uuid().nullable(),
   initial_head_count: z.preprocess(
     (val) => (val === null || val === '' ? null : parseInt(val as string)),
     z.number().nullable(),
@@ -32,22 +33,23 @@ const accountsSchema = z.object({
   expiration_date: z.date().nullable(),
   delivery_date_of_membership_ids: z.date().nullable(),
   orientation_date: z.date().nullable(),
-  initial_contract_value: z.preprocess(
-    (val) => (val === null || val === '' ? null : parseFloat(val as string)),
-    z.number().nullable(),
-  ),
-  mode_of_payment_id: z.string().nullable(),
+  initial_contract_value: z.preprocess((val) => {
+    if (val === null || val === '') return null
+    const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+    return isNaN(parsedVal) ? null : parsedVal
+  }, z.number().nullable()),
+  mode_of_payment_id: z.string().uuid().nullable(),
   wellness_lecture_date: z.date().nullable(),
   annual_physical_examination_date: z.date().nullable(),
   commision_rate: z.preprocess(
     (val) => (val === null || val === '' ? null : parseFloat(val as string)),
     z.number().min(0).max(100).nullable(),
   ),
-  additional_benefits: z.string().nullable(),
-  special_benefits: z.string().nullable(),
-  name_of_signatory: z.string().nullable(),
-  designation_of_contact_person: z.string().nullable(),
-  email_address_of_contact_person: z.string().nullable(),
+  additional_benefits: z.string().max(1000).nullable(),
+  special_benefits: z.string().max(1000).nullable(),
+  name_of_signatory: z.string().max(255).nullable(),
+  designation_of_contact_person: z.string().max(255).nullable(),
+  email_address_of_contact_person: z.string().email().nullable(),
 })
 
 export default accountsSchema

--- a/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
+++ b/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
@@ -33,6 +33,7 @@ import { FC } from 'react'
 import { ControllerRenderProps, useFormContext } from 'react-hook-form'
 import { z } from 'zod'
 import accountsSchema from '../accounts-schema'
+import currencyOptions from '@/components/maskito/currency-options'
 
 interface Props {
   isLoading: boolean
@@ -58,7 +59,9 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
     field.onChange(value)
   }
 
-  const maskedPercentageRef = useMaskito({ options: percentageOptions })
+  const maskedCommissionRateRef = useMaskito({ options: percentageOptions })
+  const maskedInitialContractValueRef = useMaskito({ options: currencyOptions })
+  const maskedTotalPremiumPaidRef = useMaskito({ options: currencyOptions })
 
   return (
     <>
@@ -270,10 +273,10 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
               <FormControl>
                 <Input
                   {...field}
-                  type="number"
                   value={field.value ?? ''}
                   disabled={isLoading}
-                  onChange={(e) => handleInputChange(field, e)}
+                  onInput={field.onChange}
+                  ref={maskedTotalPremiumPaidRef}
                 />
               </FormControl>
               <FormMessage />
@@ -728,11 +731,11 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
               <FormControl>
                 <Input
                   {...field}
-                  type="number"
                   placeholder="Enter initial contract value"
                   value={field.value ?? ''}
-                  onChange={(e) => handleInputChange(field, e)}
+                  onInput={field.onChange}
                   disabled={isLoading}
+                  ref={maskedInitialContractValueRef}
                 />
               </FormControl>
               <FormMessage />
@@ -775,9 +778,9 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
                   type="text"
                   placeholder="Enter commission rate"
                   value={field.value ?? ''}
-                  // @ts-ignore
-                  onInput={(e) => form.setValue(field.name, e.target.value)}
-                  ref={maskedPercentageRef}
+                  onInput={field.onChange}
+                  ref={maskedCommissionRateRef}
+                  disabled={isLoading}
                 />
               </FormControl>
               <FormMessage />

--- a/src/components/maskito/currency-options.ts
+++ b/src/components/maskito/currency-options.ts
@@ -1,0 +1,9 @@
+import { maskitoNumberOptionsGenerator } from '@maskito/kit'
+
+export default maskitoNumberOptionsGenerator({
+  decimalZeroPadding: true,
+  precision: 2,
+  decimalSeparator: '.',
+  min: 0,
+  prefix: '₱',
+})


### PR DESCRIPTION
### TL;DR

Enhanced form validation and input formatting for the accounts schema and marketing inputs.

### What changed?

- Updated `accountsSchema` with more specific validations:
  - Added max length constraints for string fields
  - Specified UUID format for ID fields
  - Improved parsing for numeric fields, including currency handling
  - Added email validation for contact person's email address

- Modified `MarketingInputs` component:
  - Implemented currency masking for total premium paid and initial contract value
  - Refined commission rate input with percentage masking
  - Adjusted input types and event handlers for better user experience

- Added a new `currency-options.ts` file with currency formatting options

### How to test?

1. Navigate to the accounts form in the dashboard
2. Test input fields with various valid and invalid inputs:
   - Enter long strings to check max length constraints
   - Input currency values with and without the ₱ symbol
   - Enter commission rates and check percentage formatting
   - Try invalid email addresses for the contact person
3. Verify that form validation works as expected
4. Check that currency inputs are properly formatted with the ₱ symbol and decimal places

### Why make this change?

This change improves data integrity and user experience by:
1. Enforcing stricter validation rules to ensure data consistency
2. Providing better input formatting for currency and percentage fields
3. Enhancing the overall robustness of the form handling process

These improvements will lead to more accurate data collection and reduce the likelihood of errors in the accounts management system.