### PR TITLE
TIM-512 feat(accounts): add currency masking on "edit account form"

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
@@ -21,6 +21,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import getTypes from '@/queries/get-types'
+import { useMaskito } from '@maskito/react'
+import currencyOptions from '@/components/maskito/currency-options'
 
 const CompanyInformationItem = ({
   label,
@@ -46,6 +48,7 @@ const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
   const { data: hmoProviders } = useQuery(getTypes(supabase, 'hmo_providers'))
   const { data: planTypes } = useQuery(getTypes(supabase, 'plan_types'))
 
+  const maskedTotalPremiumPaidRef = useMaskito({ options: currencyOptions })
   return (
     <>
       {editMode ? (
@@ -237,13 +240,14 @@ const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
               <FormItem>
                 <FormControl>
                   <div className="flex flex-row pt-4">
-                    <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
+                    <div className="text-md flex w-full flex-row text-[#1e293b] md:grid md:grid-cols-2 lg:grid-cols-1">
                       Total Premium Paid:
                       <Input
                         className="w-full"
                         {...field}
-                        type="number"
-                        value={field.value?.toString()}
+                        value={field.value ?? ''}
+                        ref={maskedTotalPremiumPaidRef}
+                        onInput={field.onChange}
                       />
                     </div>
                   </div>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -1,18 +1,20 @@
-import React, { FC } from 'react'
-import { createBrowserClient } from '@/utils/supabase'
-import getAccountById from '@/queries/get-account-by-id'
-import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import { Input } from '@/components/ui/input'
 import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
 import companyEditsSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edits-schema'
+import currencyOptions from '@/components/maskito/currency-options'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
 import {
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from '@/components/ui/form'
-import { useFormContext } from 'react-hook-form'
-import { z } from 'zod'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import {
   Select,
   SelectContent,
@@ -20,17 +22,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import getAccountById from '@/queries/get-account-by-id'
 import getTypes from '@/queries/get-types'
-import { Calendar } from '@/components/ui/calendar'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { Button } from '@/components/ui/button'
+import { createBrowserClient } from '@/utils/supabase'
 import { cn } from '@/utils/tailwind'
-import { CalendarIcon } from 'lucide-react'
+import { useMaskito } from '@maskito/react'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import { format } from 'date-fns'
+import { CalendarIcon } from 'lucide-react'
+import { FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
 
 const CompanyInformationItem = ({
   label,
@@ -63,6 +65,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
     getTypes(supabase, 'mode_of_premium'),
   )
 
+  const maskedInitialContractValueRef = useMaskito({ options: currencyOptions })
   return (
     <>
       {editMode ? (
@@ -73,13 +76,14 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             render={({ field }) => (
               <FormItem>
                 <div className="flex flex-row pt-4">
-                  <div className="text-md flex grid w-full flex-row text-[#1e293b] md:grid-cols-2 lg:grid-cols-1">
+                  <div className="text-md flex w-full flex-row text-[#1e293b] md:grid md:grid-cols-2 lg:grid-cols-1">
                     Initial Contract Value:
                     <Input
                       className="w-full"
                       {...field}
-                      type="number"
-                      value={field.value?.toString()}
+                      value={field.value ?? ''}
+                      onInput={field.onChange}
+                      ref={maskedInitialContractValueRef}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
### TL;DR

Added currency masking to input fields for total premium paid and initial contract value.

### What changed?

- Implemented `useMaskito` hook with currency options for the "Total Premium Paid" input in the company HMO information section.
- Added similar currency masking for the "Initial Contract Value" input in the company contract information section.
- Replaced `type="number"` with custom masked inputs for better currency formatting.
- Updated input handling to use `onInput` instead of direct value assignment.

### How to test?

1. Navigate to the company profile page.
2. Enter values in the "Total Premium Paid" field in the HMO information section.
3. Enter values in the "Initial Contract Value" field in the contract information section.
4. Verify that the inputs are formatted as currency (e.g., with commas for thousands and two decimal places).
5. Ensure that only valid numeric input is accepted and properly formatted.

### Why make this change?

This change improves the user experience by providing a more intuitive and standardized way of entering currency values. It helps prevent input errors and ensures consistency in how monetary amounts are displayed and stored throughout the application.