### PR TITLE
TIM-513 feat(billing-statements): add masking on input form

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/billing-statement-schema.ts
+++ b/src/app/(dashboard)/(home)/billing-statements/billing-statement-schema.ts
@@ -7,22 +7,21 @@ const BillingStatementSchema = z
     or_number: z.string().optional(),
     or_date: z.date().optional(),
     sa_number: z.string().optional(),
-    amount: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
-    total_contract_value: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
-    balance: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
-
+    amount: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
+    total_contract_value: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
+    balance: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
     billing_period: z.preprocess(
       (val) =>
         val === '' || val === undefined
@@ -30,26 +29,26 @@ const BillingStatementSchema = z
           : parseInt(val as string, 10),
       z.number().int().min(1).max(31).optional(),
     ),
-    amount_billed: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
-    amount_paid: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
+    amount_billed: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
+    amount_paid: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
     commission_rate: z.preprocess(
       (val) =>
         val === '' || val === undefined ? undefined : parseFloat(val as string),
       z.number().positive().optional(),
     ),
-    commission_earned: z.preprocess(
-      (val) =>
-        val === '' || val === undefined ? undefined : parseFloat(val as string),
-      z.number().positive().optional(),
-    ),
+    commission_earned: z.preprocess((val) => {
+      if (val === '' || val === undefined) return undefined
+      const parsedVal = parseFloat((val as string).replace(/[₱,\s]/g, ''))
+      return isNaN(parsedVal) ? undefined : parsedVal
+    }, z.number().positive().optional()),
     account_id: z.string().uuid(),
   })
   .superRefine((data, ctx) => {

--- a/src/components/maskito/percentage-options.ts
+++ b/src/components/maskito/percentage-options.ts
@@ -1,5 +1,8 @@
 import type { MaskitoOptions } from '@maskito/core'
-import { maskitoUpdateElement } from '@maskito/core'
+import {
+  maskitoInitialCalibrationPlugin,
+  maskitoUpdateElement,
+} from '@maskito/core'
 import {
   maskitoCaretGuard,
   maskitoEventHandler,
@@ -18,6 +21,7 @@ export default {
   ...numberOptions,
   plugins: [
     ...plugins,
+    maskitoInitialCalibrationPlugin(),
     // Forbids caret to be placed after postfix
     maskitoCaretGuard((value) => [0, value.length - 1]),
     maskitoEventHandler('blur', (element) => {


### PR DESCRIPTION
### TL;DR

Enhanced billing statement form with currency and percentage input masking.

### What changed?

- Updated `BillingStatementSchema` to handle currency formatting and parsing
- Implemented Maskito for currency and percentage input fields in the billing statement modal
- Added currency and percentage masking to form fields: amount, total contract value, balance, amount billed, amount paid, commission rate, and commission earned
- Improved data handling when editing existing billing statements
- Added table rerendering functionality to ensure updates are reflected immediately

### How to test?

1. Open the billing statement modal for creating or editing a statement
2. Enter values in the currency fields (e.g., amount, total contract value) and observe the automatic formatting
3. Enter a percentage in the commission rate field and check for proper formatting
4. Submit the form and verify that the values are correctly processed and saved
5. Edit an existing billing statement and ensure that the values are properly displayed and formatted in the form

### Why make this change?

This change improves the user experience by providing automatic formatting for currency and percentage inputs, reducing the likelihood of data entry errors. It also ensures consistent data handling and display across the application, making it easier for users to work with financial information in the billing statements.