### PR TITLE
feat(company): implement currency and percentage input masks

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -6,12 +6,15 @@ import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Person
 import CompanyHMOInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information'
 import CompanyInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information'
 import accountsSchema from '@/app/(dashboard)/(home)/accounts/accounts-schema'
+import currencyOptions from '@/components/maskito/currency-options'
+import percentageOptions from '@/components/maskito/percentage-options'
 import { Button } from '@/components/ui/button'
 import { Form } from '@/components/ui/form'
 import { toast } from '@/components/ui/use-toast'
 import getAccountById from '@/queries/get-account-by-id'
 import { createBrowserClient } from '@/utils/supabase'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { maskitoTransform } from '@maskito/core'
 import {
   useQuery,
   useUpdateMutation,
@@ -51,7 +54,12 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
         ? (account.account_type as any).id
         : null,
       total_utilization: account?.total_utilization ?? null,
-      total_premium_paid: account?.total_premium_paid ?? null,
+      total_premium_paid: account?.total_premium_paid
+        ? (maskitoTransform(
+            account.total_premium_paid.toString(),
+            currencyOptions,
+          ) as unknown as number)
+        : null,
       signatory_designation: account?.signatory_designation ?? null,
       contact_person: account?.contact_person ?? null,
       contact_number: account?.contact_number ?? null,
@@ -77,7 +85,12 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
       orientation_date: account?.orientation_date
         ? new Date(account.orientation_date)
         : null,
-      initial_contract_value: account?.initial_contract_value ?? null,
+      initial_contract_value: account?.initial_contract_value
+        ? (maskitoTransform(
+            account.initial_contract_value.toString(),
+            currencyOptions,
+          ) as unknown as number)
+        : null,
       mode_of_payment_id: account?.mode_of_payment
         ? (account.mode_of_payment as any).id
         : null,
@@ -88,7 +101,12 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
         account?.annual_physical_examination_date
           ? new Date(account.annual_physical_examination_date)
           : null,
-      commision_rate: account?.commision_rate ?? null,
+      commision_rate: account?.commision_rate
+        ? (maskitoTransform(
+            account.commision_rate.toString(),
+            percentageOptions,
+          ) as unknown as number)
+        : null,
       additional_benefits: account?.additional_benefits ?? null,
       special_benefits: account?.special_benefits ?? null,
       name_of_signatory: account?.name_of_signatory ?? null,

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -54,15 +54,12 @@ interface CompanyContractInformationProps {
 const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
   id,
 }) => {
-  const { editMode, setEditMode } = useCompanyEditContext()
+  const { editMode } = useCompanyEditContext()
   const form = useFormContext<z.infer<typeof companyEditsSchema>>()
   const supabase = createBrowserClient()
   const { data: account } = useQuery(getAccountById(supabase, id))
   const { data: modeOfPayments } = useQuery(
     getTypes(supabase, 'mode_of_payments'),
-  )
-  const { data: modeOfPremiums, isLoading: isModeOfPremiumLoading } = useQuery(
-    getTypes(supabase, 'mode_of_premium'),
   )
 
   const maskedInitialContractValueRef = useMaskito({ options: currencyOptions })


### PR DESCRIPTION
### TL;DR

Added currency and percentage masking to company profile fields and removed unused code.

### What changed?

- Implemented currency masking for `total_premium_paid` and `initial_contract_value` fields
- Added percentage masking for `commision_rate` field
- Imported `currencyOptions` and `percentageOptions` from maskito components
- Removed unused `setEditMode` from `useCompanyEditContext()`
- Removed unused query for `modeOfPremiums` and its loading state

### How to test?

1. Navigate to a company's profile page
2. Verify that `total_premium_paid` and `initial_contract_value` fields display currency formatting
3. Check that the `commision_rate` field shows percentage formatting
4. Ensure that the company profile loads correctly without any errors related to removed code

### Why make this change?

This change improves data consistency and user experience by applying appropriate formatting to currency and percentage fields. It also removes unused code, which helps maintain a cleaner and more efficient codebase.