### PR TITLE
TIM-514 feat(billing-statements): improve upsert mutation when creating/editing billing statements

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
+++ b/src/app/(dashboard)/(home)/accounts/forms/marketing-inputs.tsx
@@ -905,6 +905,7 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
                   placeholder="Enter additional benefits"
                   value={field.value ?? ''}
                   onChange={(e) => handleInputChange(field, e)}
+                  disabled={isLoading}
                 />
               </FormControl>
               <FormMessage />
@@ -923,6 +924,7 @@ const MarketingInputs: FC<Props> = ({ isLoading }) => {
                   placeholder="Enter special benefits"
                   value={field.value ?? ''}
                   onChange={(e) => handleInputChange(field, e)}
+                  disabled={isLoading}
                 />
               </FormControl>
               <FormMessage />


### PR DESCRIPTION
### TL;DR

Improved billing statement modal functionality and form handling.

### What changed?

- Replaced separate insert and update mutations with a single upsert mutation for billing statements.
- Updated form submission logic to use the new upsert mutation.
- Simplified state management by removing unnecessary query client invalidation.
- Improved toast messages to differentiate between creation and update actions.
- Added `disabled` prop to additional input fields in the marketing inputs form.

### How to test?

1. Open the billing statement modal.
2. Create a new billing statement and verify it's added successfully.
3. Edit an existing billing statement and confirm the changes are saved.
4. Check that appropriate toast messages appear for both creation and update actions.
5. Verify that form fields are disabled during submission.
6. Test the marketing inputs form and ensure the new disabled fields behave correctly when loading.

### Why make this change?

This change streamlines the billing statement management process by using a single upsert mutation instead of separate insert and update operations. It simplifies the codebase, reduces redundancy, and improves the overall user experience by providing more accurate feedback and consistent form behavior during submissions.