### PR TITLE
TIM-517 delete(rpc): unused rpc search functions

### DIFF
--- a/supabase/migrations/20241027110502_delete_rcp_search_function.sql
+++ b/supabase/migrations/20241027110502_delete_rcp_search_function.sql
@@ -1,0 +1,5 @@
+DROP FUNCTION IF EXISTS public.search_billing_statements;
+
+DROP FUNCTION IF EXISTS public.search_accounts;
+
+DROP EXTENSION IF EXISTS pg_trgm CASCADE;


### PR DESCRIPTION
### TL;DR

Removed unused search functions from the database.

### What changed?

This migration removes two SQL functions:
- `public.search_billing_statements`
- `public.search_accounts`

### How to test?

1. Apply the migration to your local database.
2. Attempt to call these functions in your SQL client or application.
3. Verify that you receive an error indicating that these functions no longer exist.

### Why make this change?

These search functions are no longer used in the application, and removing them helps to clean up the database schema. This change reduces clutter and potential confusion for developers working on the project.