### PR TITLE
feat(agents): improve add agent form with query invalidation and modal closure

### DIFF
--- a/src/app/(dashboard)/admin/agents/create/add-agent-form.tsx
+++ b/src/app/(dashboard)/admin/agents/create/add-agent-form.tsx
@@ -12,14 +12,20 @@ import {
 import { Input } from '@/components/ui/input'
 import { SheetClose } from '@/components/ui/sheet'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-const AddAgentForm = () => {
+interface Props {
+  setIsOpen: (isOpen: boolean) => void
+}
+
+const AddAgentForm = ({ setIsOpen }: Props) => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
+  const queryClient = useQueryClient()
   const form = useForm<z.infer<typeof agentSchema>>({
     resolver: zodResolver(agentSchema),
     defaultValues: {
@@ -52,8 +58,11 @@ const AddAgentForm = () => {
       setError(data.error)
     }
 
+    // clean up
     form.reset()
+    queryClient.invalidateQueries()
     setIsLoading(false)
+    setIsOpen(false)
   }
   return (
     <Form {...form}>
@@ -101,14 +110,6 @@ const AddAgentForm = () => {
           />
         </div>
         <div className="fixed bottom-0 flex w-full flex-row items-center justify-end gap-2 bg-[#f1f5f9] px-4 py-3 md:max-w-2xl">
-          {/* <Button
-            type="button"
-            variant="ghost"
-            className="text-destructive"
-            disabled={isLoading}
-          >
-            Delete
-          </Button> */}
           <div className="flex flex-row items-center justify-center">
             <SheetClose asChild={true}>
               <Button type="button" variant="ghost" disabled={isLoading}>

--- a/src/app/(dashboard)/admin/agents/create/add-agent.tsx
+++ b/src/app/(dashboard)/admin/agents/create/add-agent.tsx
@@ -10,10 +10,12 @@ import { Plus, X } from 'lucide-react'
 import config from 'next/config'
 import Avatar from 'react-nice-avatar'
 import AddAgentForm from './add-agent-form'
+import { useState } from 'react'
 
 const AddAgent = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
   return (
-    <Sheet>
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild={true}>
         <Button className="space-x-2">
           <Plus />
@@ -33,7 +35,7 @@ const AddAgent = () => {
             className="mx-6 h-32 w-32 -translate-y-16 rounded-full border-4 border-card"
             {...config}
           />
-          <AddAgentForm />
+          <AddAgentForm setIsOpen={setIsOpen} />
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
### TL;DR

Enhanced the Add Agent functionality with improved state management and query invalidation.

### What changed?

- Added `setIsOpen` prop to `AddAgentForm` component for better control of the form's visibility.
- Implemented `useQueryClient` hook to invalidate queries after form submission.
- Removed commented-out delete button from the form.
- Introduced `isOpen` state in the `AddAgent` component to control the Sheet's open/close state.
- Updated the Sheet component to use the `isOpen` state for better control.

### How to test?

1. Navigate to the Admin Agents page.
2. Click the "Add Agent" button to open the form.
3. Fill out the form and submit.
4. Verify that the form closes automatically upon successful submission.
5. Check that the agents list updates immediately without manual refresh.

### Why make this change?

This change improves the user experience by automatically closing the form and refreshing the agent list after successful submission. It also enhances the component's reusability by allowing external control of its open/close state. The removal of unused code (commented-out delete button) helps maintain a cleaner codebase.