### PR TITLE
feat(accounts): redirect to new account after creation

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
@@ -10,9 +10,10 @@ import accountsSchema from './accounts-schema'
 import MarketingInputs from './forms/marketing-inputs'
 import { useInsertMutation } from '@supabase-cache-helpers/postgrest-react-query'
 import { createBrowserClient } from '@/utils/supabase'
-import { FormEventHandler, useCallback } from 'react'
+import { FormEventHandler, useCallback, useEffect } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useToast } from '@/components/ui/use-toast'
+import { useRouter } from 'next/navigation'
 
 const AddAccountForm = () => {
   const { isFormOpen, setIsFormOpen } = useAccountsContext()
@@ -56,7 +57,8 @@ const AddAccountForm = () => {
   })
 
   const supabase = createBrowserClient()
-  const { mutateAsync, isPending } = useInsertMutation(
+  const router = useRouter()
+  const { mutateAsync, isPending, data } = useInsertMutation(
     // @ts-ignore
     supabase.from('accounts'),
     ['id'],
@@ -70,7 +72,6 @@ const AddAccountForm = () => {
         setIsFormOpen(false)
       },
       onError: (error) => {
-        console.log(error)
         toast({
           title: 'Something went wrong',
           description: error.message,
@@ -79,6 +80,13 @@ const AddAccountForm = () => {
       },
     },
   )
+
+  // redirect to the new account
+  useEffect(() => {
+    if (data) {
+      router.push(`/accounts/${data[0].id}`)
+    }
+  }, [data, router])
 
   const onSubmitHandler = useCallback<FormEventHandler<HTMLFormElement>>(
     (e) => {


### PR DESCRIPTION
### TL;DR

Added redirection to the newly created account page after successful form submission.

### What changed?

- Imported `useRouter` from Next.js navigation
- Added `data` to the destructured values from `useInsertMutation`
- Implemented a `useEffect` hook to redirect the user to the new account page after successful creation
- Removed a console.log statement for error handling

### How to test?

1. Navigate to the account creation form
2. Fill out the form with valid data
3. Submit the form
4. Verify that you are automatically redirected to the newly created account's page

### Why make this change?

This change improves the user experience by automatically redirecting users to the newly created account page after successful form submission. It eliminates the need for manual navigation and provides immediate access to the new account's details.