### PR TITLE
feat(accounts): refactor account count fetching with getAccounts query

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/data-table.tsx
@@ -36,6 +36,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import AccountsProvider from './accounts-provider'
 import AddAccountButton from './add-account-button'
+import getAccounts from '@/queries/get-accounts'
 
 interface IData {
   id: string
@@ -75,9 +76,7 @@ const DataTable = <TData extends IData, TValue>({
   })
 
   const supabase = createBrowserClient()
-  const { count: totalCount, isLoading } = useQuery(
-    supabase.from('accounts').select('*', { head: true, count: 'exact' }),
-  )
+  const { count, isLoading } = useQuery(getAccounts(supabase))
 
   useEffect(() => {
     const upsertColumnVisibility = async () => {
@@ -145,7 +144,7 @@ const DataTable = <TData extends IData, TValue>({
               {isLoading ? (
                 <Skeleton className="h-4 w-20" />
               ) : (
-                <PageDescription>{totalCount} Accounts</PageDescription>
+                <PageDescription>{count} Accounts</PageDescription>
               )}
             </div>
             <div className="flex flex-row gap-4">


### PR DESCRIPTION
### TL;DR

Refactored account data fetching and display in the DataTable component.

### What changed?

- Imported a new `getAccounts` query function from '@/queries/get-accounts'
- Replaced the inline Supabase query with the new `getAccounts` function
- Updated the variable names from `totalCount` to `count` for consistency
- Modified the PageDescription to use the new `count` variable

### How to test?

1. Navigate to the accounts page
2. Verify that the total number of accounts is displayed correctly
3. Check that the loading state (Skeleton) works as expected
4. Ensure that adding or removing accounts updates the count accurately

### Why make this change?

This change improves code organization by moving the account fetching logic into a separate query function. It enhances maintainability and reusability of the data fetching process across the application. The consistent naming of variables also improves code readability.