### PR TITLE
feat(company): enhance delete account functionality and UI

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-delete-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-delete-button.tsx
@@ -28,7 +28,7 @@ import {
   useQuery,
   useUpdateMutation,
 } from '@supabase-cache-helpers/postgrest-react-query'
-import { Trash, X } from 'lucide-react'
+import { Loader2, Trash, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { FC, FormEventHandler, useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -53,11 +53,11 @@ const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
   const supabase = createBrowserClient()
   const { data: account } = useQuery(getAccountById(supabase, accountId))
 
-  const { mutateAsync, isPending } = useUpdateMutation(
+  const { mutateAsync, isPending, isSuccess } = useUpdateMutation(
     // @ts-ignore
     supabase.from('accounts'),
     ['id'],
-    'id',
+    null,
     {
       onSuccess: () => {
         router.push('/accounts')
@@ -68,7 +68,6 @@ const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
         })
       },
       onError: (error) => {
-        console.log(error)
         toast({
           variant: 'destructive',
           title: 'Something went wrong',
@@ -130,7 +129,7 @@ const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
                     Please type in the name of the account to confirm.
                   </FormLabel>
                   <FormControl>
-                    <Input {...field} disabled={isPending} />
+                    <Input {...field} disabled={isPending || isSuccess} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -141,9 +140,13 @@ const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
                 variant={'destructive'}
                 className="w-full"
                 type="submit"
-                disabled={isPending}
+                disabled={isPending || isSuccess}
               >
-                I understand, delete this account
+                {isPending || isSuccess ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  'I understand, delete this account'
+                )}
               </Button>
             </AlertDialogFooter>
           </form>


### PR DESCRIPTION
### TL;DR

Enhanced the company delete functionality with improved UI feedback and error handling.

### What changed?

- Added a loading spinner to the delete button during the deletion process
- Disabled the input field and delete button when the deletion is in progress or successful
- Removed console logging of errors
- Updated the mutation to use `null` instead of `'id'` for the third parameter
- Added `isSuccess` state to manage UI after successful deletion

### How to test?

1. Navigate to a company profile page
2. Click on the delete button
3. Enter the company name in the confirmation dialog
4. Submit the deletion request
5. Verify that the input field and delete button are disabled during the process
6. Confirm that a loading spinner appears on the delete button
7. Check that you're redirected to the accounts page after successful deletion
8. Attempt an invalid deletion and verify that an error toast appears

### Why make this change?

This change improves the user experience during the account deletion process by providing clear visual feedback. It prevents multiple deletion attempts, reduces the chance of user errors, and enhances the overall reliability of the deletion functionality.