### PR TITLE
feat(accounts): add null checks for account export fields

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/export-accounts.tsx
+++ b/src/app/(dashboard)/(home)/accounts/export-accounts.tsx
@@ -14,14 +14,28 @@ const ExportAccounts = () => {
 
     const accountsData = accounts.map((account) => ({
       ...account,
-      agent: account.agent?.first_name + ' ' + account.agent?.last_name,
-      hmo_count: (account.hmo_provider as any).name,
-      previous_hmo_provider: (account.previous_hmo_provider as any).name,
-      current_hmo_provider: (account.current_hmo_provider as any).name,
-      account_type: (account.account_type as any).name,
-      principal_plan_type: (account.principal_plan_type as any).name,
-      dependent_plan_type: (account.dependent_plan_type as any).name,
-      mode_of_payment: (account.mode_of_payment as any).name,
+      agent: account.agent
+        ? `${account.agent.first_name} ${account.agent.last_name}`
+        : '',
+      hmo_count: account.hmo_provider ? (account.hmo_provider as any).name : '',
+      previous_hmo_provider: account.previous_hmo_provider
+        ? (account.previous_hmo_provider as any).name
+        : '',
+      current_hmo_provider: account.current_hmo_provider
+        ? (account.current_hmo_provider as any).name
+        : '',
+      account_type: account.account_type
+        ? (account.account_type as any).name
+        : '',
+      principal_plan_type: account.principal_plan_type
+        ? (account.principal_plan_type as any).name
+        : '',
+      dependent_plan_type: account.dependent_plan_type
+        ? (account.dependent_plan_type as any).name
+        : '',
+      mode_of_payment: account.mode_of_payment
+        ? (account.mode_of_payment as any).name
+        : '',
     }))
 
     const fileName = `accounts-${new Date().toLocaleDateString('en-US', {


### PR DESCRIPTION
### TL;DR

Enhanced data handling in account export functionality

### What changed?

- Updated the `accountsData` mapping to include null checks for all fields
- Added fallback to empty string ('') for fields that might be undefined
- Improved the formatting of the agent name by using template literals

### How to test?

1. Navigate to the accounts export feature
2. Attempt to export accounts with various data configurations, including:
   - Accounts with missing or undefined fields
   - Accounts with complete data
3. Verify that the exported data handles all scenarios without errors
4. Check that empty fields are represented as blank entries rather than 'undefined'

### Why make this change?

This change improves the robustness of the account export feature by handling potential undefined values. It prevents errors that could occur when accessing properties of null objects and ensures a consistent output format, even when data is missing. This enhancement will lead to a more reliable user experience and reduce the likelihood of export failures due to data inconsistencies.