### PR TITLE
feat(billing): enhance delete billing statement functionality and UI

### DIFF
--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -129,7 +129,7 @@ const BillingStatementModal = <TData,>({
           form.reset()
         }
 
-        // rerender table
+        // rerender table to refresh masking inputs
         setTableRerender((prev) => prev + 1)
       },
       onError: (error) => {
@@ -604,7 +604,12 @@ const BillingStatementModal = <TData,>({
                 originalData && '!justify-between',
               )}
             >
-              {originalData && <DeleteBillingStatement id={originalData.id} />}
+              {originalData && (
+                <DeleteBillingStatement
+                  id={originalData.id}
+                  setOpen={setOpen}
+                />
+              )}
               <div className="space-x-2">
                 <Button
                   variant="outline"

--- a/src/components/billing-statement/delete-billing-statement.tsx
+++ b/src/components/billing-statement/delete-billing-statement.tsx
@@ -9,10 +9,12 @@ import { FC } from 'react'
 
 interface DeleteBillingStatementProps {
   id: string
+  setOpen: (_x: boolean) => void
 }
 
 const DeleteBillingStatement: FC<DeleteBillingStatementProps> = ({
   id,
+  setOpen,
 }: DeleteBillingStatementProps) => {
   const { openConfirmation } = useConfirmationStore()
   const { toast } = useToast()
@@ -30,7 +32,7 @@ const DeleteBillingStatement: FC<DeleteBillingStatementProps> = ({
           title: 'Success',
           description: 'Account deleted',
         })
-        window.location.reload()
+        setOpen(false)
       },
       onError: (error) => {
         toast({
@@ -61,6 +63,7 @@ const DeleteBillingStatement: FC<DeleteBillingStatementProps> = ({
               'This action CANNOT be undone. This will permanently delete the billing statement.',
             cancelLabel: 'Cancel',
             actionLabel: 'I understand, delete this billing statement',
+            confirmationButtonVariant: 'destructive',
             onAction: () => onDeleteHandler(),
             onCancel: () => {},
           })

--- a/src/components/confirmation-dialog/confirmationStore.ts
+++ b/src/components/confirmation-dialog/confirmationStore.ts
@@ -1,4 +1,3 @@
-import { buttonVariants } from '@/components/ui/button'
 import { create } from 'zustand'
 
 interface ConfirmationState {


### PR DESCRIPTION
### TL;DR

Improved billing statement deletion process and enhanced confirmation dialog functionality.

### What changed?

- Updated `BillingStatementModal` to pass `setOpen` function to `DeleteBillingStatement` component
- Modified `DeleteBillingStatement` to close the modal after successful deletion instead of reloading the page
- Added `confirmationButtonVariant` option to the confirmation dialog for destructive actions

### How to test?

1. Open a billing statement modal for an existing statement
2. Click the delete button
3. Confirm the deletion in the confirmation dialog
4. Verify that the modal closes and the statement is removed without page reload

### Why make this change?

This change improves the user experience by providing a smoother deletion process for billing statements. It eliminates the need for a full page reload, making the application more responsive and efficient. Additionally, the enhanced confirmation dialog allows for better visual indication of destructive actions.