### PR TITLE
feat(accounts): format date fields and enhance agent name display

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
+++ b/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
@@ -3,6 +3,7 @@ import TableHeader from '@/components/table-header'
 import getAccounts from '@/queries/get-accounts'
 import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
+import { format } from 'date-fns'
 
 export const formatCurrency = (value: number | null | undefined) => {
   if (value === null || value === undefined) {
@@ -49,6 +50,8 @@ const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
         `${row.original.agent.first_name} ${row.original.agent.last_name}`
       )
     },
+    accessorFn: (originalRow) =>
+      `${(originalRow as any).agent?.first_name ?? ''} ${(originalRow as any).agent?.last_name ?? ''}`,
   },
   {
     accessorKey: 'company_address',
@@ -135,30 +138,53 @@ const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
     header: ({ column }) => (
       <TableHeader column={column} title="Effectivity Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.effectivity_date
+        ? format((originalRow as any).effectivity_date, 'MMMM dd, yyyy')
+        : '',
   },
   {
     accessorKey: 'coc_issue_date',
     header: ({ column }) => (
       <TableHeader column={column} title="COC Issue Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.coc_issue_date
+        ? format((originalRow as any).coc_issue_date, 'MMMM dd, yyyy')
+        : '',
   },
   {
     accessorKey: 'expiration_date',
     header: ({ column }) => (
       <TableHeader column={column} title="Expiration Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.expiration_date
+        ? format((originalRow as any).expiration_date, 'MMMM dd, yyyy')
+        : '',
   },
   {
     accessorKey: 'delivery_date_of_membership_ids',
     header: ({ column }) => (
       <TableHeader column={column} title="Delivery Date of Membership IDs" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.delivery_date_of_membership_ids
+        ? format(
+            (originalRow as any).delivery_date_of_membership_ids,
+            'MMMM dd, yyyy',
+          )
+        : '',
   },
   {
     accessorKey: 'orientation_date',
     header: ({ column }) => (
       <TableHeader column={column} title="Orientation Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.orientation_date
+        ? format((originalRow as any).orientation_date, 'MMMM dd, yyyy')
+        : '',
   },
   {
     accessorKey: 'initial_contract_value',
@@ -179,12 +205,23 @@ const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
     header: ({ column }) => (
       <TableHeader column={column} title="Wellness Lecture Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.wellness_lecture_date
+        ? format((originalRow as any).wellness_lecture_date, 'MMMM dd, yyyy')
+        : '',
   },
   {
     accessorKey: 'annual_physical_examination_date',
     header: ({ column }) => (
       <TableHeader column={column} title="Annual Physical Examination Date" />
     ),
+    accessorFn: (originalRow) =>
+      (originalRow as any)?.annual_physical_examination_date
+        ? format(
+            (originalRow as any).annual_physical_examination_date,
+            'MMMM dd, yyyy',
+          )
+        : '',
   },
   {
     accessorKey: 'commision_rate',


### PR DESCRIPTION
### TL;DR

Enhanced date formatting and added accessorFn for various columns in the accounts table.

### What changed?

- Imported the `format` function from `date-fns` library.
- Added `accessorFn` to the "Agent" column to properly format the agent's full name.
- Implemented `accessorFn` for date-related columns to format dates using the `MMMM dd, yyyy` pattern.
- Applied date formatting to the following columns:
  - Effectivity Date
  - COC Issue Date
  - Expiration Date
  - Delivery Date of Membership IDs
  - Orientation Date
  - Wellness Lecture Date
  - Annual Physical Examination Date

### How to test?

1. Navigate to the accounts table in the dashboard.
2. Verify that the "Agent" column displays full names correctly.
3. Check that all date columns (listed above) are formatted as "Month DD, YYYY".
4. Ensure that empty date fields are displayed as blank instead of showing invalid dates.

### Why make this change?

This change improves the readability and consistency of the accounts table. By formatting dates uniformly and ensuring proper display of agent names, users can more easily interpret and analyze the data presented in the table.