### PR TITLE
feat(accounts): remove role-based access control from AddAccountButton

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/add-account-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/add-account-button.tsx
@@ -9,30 +9,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import getRole from '@/utils/get-role'
-import { useQuery } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
 const AddAccountButton = () => {
   const [isOpen, setIsOpen] = useState(false)
-  const allowedRole = [
-    'admin',
-    'marketing',
-    'finance',
-    'under-writing',
-    'after-sales',
-  ]
-
-  const { data: role } = useQuery({
-    queryKey: ['role'],
-    queryFn: () => getRole(),
-  })
-
-  if (!role || !allowedRole.includes(role)) {
-    return null
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>


### PR DESCRIPTION
### TL;DR

Simplified the AddAccountButton component by removing role-based access control.

### What changed?

- Removed the `useQuery` hook for fetching user roles
- Eliminated the `allowedRole` array and associated role check
- Removed the import for `getRole` utility function

### How to test?

1. Navigate to the accounts page
2. Verify that the "Add Account" button is visible for all users, regardless of their role
3. Ensure the button still opens the dialog when clicked

### Why make this change?

This change simplifies the component and removes role-based restrictions on the "Add Account" button. It suggests that the decision was made to allow all users to access this functionality, potentially streamlining the user experience and reducing complexity in the codebase.