### PR TITLE
TIM-550 fix(billing-statements): billing statements should also be deleted when its parent account is deleted

### DIFF
--- a/src/queries/get-all-accounts.ts
+++ b/src/queries/get-all-accounts.ts
@@ -4,6 +4,7 @@ const getAllAccounts = (supabase: TypedSupabaseClient) => {
   return supabase
     .from('accounts')
     .select('id, company_name')
+    .eq('is_active', true)
     .order('created_at', { ascending: true })
     .throwOnError()
 }

--- a/src/queries/get-billing-statements.ts
+++ b/src/queries/get-billing-statements.ts
@@ -20,7 +20,7 @@ const getBillingStatements = (supabase: TypedSupabaseClient) => {
     commission_earned,
     created_at,
     updated_at,
-    account:accounts(id, company_name),
+    account:accounts!inner(id, company_name, is_active),
     mode_of_payment:mode_of_payments(id, name)
   `,
       {
@@ -28,6 +28,7 @@ const getBillingStatements = (supabase: TypedSupabaseClient) => {
       },
     )
     .eq('is_active', true)
+    .eq('account.is_active', true)
     .order('created_at', { ascending: false })
     .throwOnError()
 }


### PR DESCRIPTION
### TL;DR

Filter active accounts in queries and join statements

### What changed?

- In `get-all-accounts.ts`, added a filter to only return active accounts
- In `get-billing-statements.ts`, updated the join with accounts table to use inner join and include `is_active` field
- Added a filter to ensure only active accounts are included in billing statements

### How to test?

1. Run the `getAllAccounts` query and verify that only active accounts are returned
2. Execute the `getBillingStatements` query and confirm that:
   - Only billing statements associated with active accounts are retrieved
   - The `account` object in the results includes the `is_active` field

### Why make this change?

To ensure that queries only return data for active accounts, improving data consistency and preventing potential issues with inactive accounts in the system. This change also allows for better filtering and management of account-related information in the application.