### PR TITLE
feat(company): refactor CompanyInformationItem and improve data display

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
@@ -1,18 +1,15 @@
-import React, { FC } from 'react'
-import { createBrowserClient } from '@/utils/supabase'
-import getAccountById from '@/queries/get-account-by-id'
-import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import { Input } from '@/components/ui/input'
 import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
 import companyEditsSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edits-schema'
-import { useFormContext } from 'react-hook-form'
-import { z } from 'zod'
+import CompanyInformationItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item'
+import { formatCurrency } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
+import currencyOptions from '@/components/maskito/currency-options'
 import {
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -20,29 +17,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import getAccountById from '@/queries/get-account-by-id'
 import getTypes from '@/queries/get-types'
+import { createBrowserClient } from '@/utils/supabase'
 import { useMaskito } from '@maskito/react'
-import currencyOptions from '@/components/maskito/currency-options'
-import { formatCurrency } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
 
-const CompanyInformationItem = ({
-  label,
-  value,
-}: {
-  label: string
-  value?: string | undefined
-}) => (
-  <div className="flex flex-col py-1">
-    <div className="text-sm font-medium text-muted-foreground">{label}</div>
-    <div className="text-md font-semibold">{value || 'No data'}</div>
-  </div>
-)
 interface CompanyHmoInformationProps {
   id: string
 }
 
 const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
-  const { editMode, setEditMode } = useCompanyEditContext()
+  const { editMode } = useCompanyEditContext()
   const form = useFormContext<z.infer<typeof companyEditsSchema>>()
   const supabase = createBrowserClient()
   const { data: account } = useQuery(getAccountById(supabase, id))

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
@@ -25,19 +25,7 @@ import getAgents from '@/queries/get-agents'
 import { useMaskito } from '@maskito/react'
 import percentageOptions from '@/components/maskito/percentage-options'
 import { formatPercentage } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
-
-const CompanyInformationItem = ({
-  label,
-  value,
-}: {
-  label: string
-  value?: string | undefined
-}) => (
-  <div className="flex flex-col py-1">
-    <div className="text-sm font-medium text-muted-foreground">{label}</div>
-    <div className="text-md font-semibold">{value || 'No data'}</div>
-  </div>
-)
+import CompanyInformationItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item'
 
 interface CompanyAccountInformationProps {
   id: string
@@ -165,7 +153,7 @@ const CompanyAccountInformation: FC<CompanyAccountInformationProps> = ({
             value={
               account?.agent
                 ? `${account?.agent?.first_name} ${account?.agent?.last_name}`
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -34,19 +34,7 @@ import { FC } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { z } from 'zod'
 import { formatCurrency } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
-
-const CompanyInformationItem = ({
-  label,
-  value,
-}: {
-  label: string
-  value?: string | undefined
-}) => (
-  <div className="flex flex-col py-1">
-    <div className="text-sm font-medium text-muted-foreground">{label}</div>
-    <div className="text-md font-semibold">{value || 'No data'}</div>
-  </div>
-)
+import CompanyInformationItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item'
 
 interface CompanyContractInformationProps {
   id: string
@@ -566,7 +554,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             value={
               account?.expiration_date
                 ? format(new Date(account.expiration_date), 'PPP')
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -574,7 +562,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             value={
               account?.effectivity_date
                 ? format(new Date(account.effectivity_date), 'PPP')
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -583,7 +571,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             value={
               account?.coc_issue_date
                 ? format(new Date(account.coc_issue_date), 'PPP')
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -594,7 +582,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
                     new Date(account.delivery_date_of_membership_ids),
                     'PPP',
                   )
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -603,7 +591,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             value={
               account?.orientation_date
                 ? format(new Date(account.orientation_date), 'PPP')
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -611,7 +599,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
             value={
               account?.wellness_lecture_date
                 ? format(new Date(account.wellness_lecture_date), 'PPP')
-                : 'No data'
+                : undefined
             }
           />
           <CompanyInformationItem
@@ -622,7 +610,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
                     new Date(account.annual_physical_examination_date),
                     'PPP',
                   )
-                : 'No data'
+                : undefined
             }
           />
         </div>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item.tsx
@@ -1,0 +1,14 @@
+const CompanyInformationItem = ({
+  label,
+  value,
+}: {
+  label: string
+  value?: string | undefined
+}) => (
+  <div className="flex flex-col py-1">
+    <div className="text-sm font-medium text-muted-foreground">{label}</div>
+    <div className="text-md font-semibold">{value || '-'}</div>
+  </div>
+)
+
+export default CompanyInformationItem

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information.tsx
@@ -13,19 +13,7 @@ import { useFormContext } from 'react-hook-form'
 import { z } from 'zod'
 import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
 import companyEditsSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edits-schema'
-
-const CompanyInformationItem = ({
-  label,
-  value,
-}: {
-  label: string
-  value?: string | undefined
-}) => (
-  <div className="flex flex-col py-1">
-    <div className="text-sm font-medium text-muted-foreground">{label}</div>
-    <div className="text-md font-semibold">{value || 'No data'}</div>
-  </div>
-)
+import CompanyInformationItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information-item'
 
 interface CompanyInformationProps {
   id: string


### PR DESCRIPTION
### TL;DR

Refactored company profile components and introduced a reusable CompanyInformationItem component.

### What changed?

- Created a new `CompanyInformationItem` component in a separate file.
- Updated imports and removed duplicate `CompanyInformationItem` definitions in various files.
- Standardized the display of empty values to show a dash ('-') instead of 'No data'.
- Adjusted the rendering of agent names and dates to use `undefined` for consistency.
- Removed unused imports and variables.

### How to test?

1. Navigate to the company profile pages for different accounts.
2. Verify that all information is displayed correctly, with empty values showing as '-'.
3. Check that dates and agent names are formatted properly.
4. Ensure that the edit mode functionality still works as expected.

### Why make this change?

This refactoring improves code maintainability and consistency across the company profile components. By centralizing the `CompanyInformationItem` component, we reduce code duplication and make it easier to apply future changes uniformly. The standardization of empty value display enhances the user experience by providing a consistent visual representation throughout the interface.