### PR TITLE
feat(pending): add pending accounts table

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -528,6 +528,193 @@ export type Database = {
         }
         Relationships: []
       }
+      pending_accounts: {
+        Row: {
+          account_type_id: string | null
+          additional_benefits: string | null
+          agent_id: string | null
+          annual_physical_examination_date: string | null
+          coc_issue_date: string | null
+          commision_rate: number | null
+          company_address: string | null
+          company_name: string
+          contact_number: string | null
+          contact_person: string | null
+          created_at: string
+          created_by: string | null
+          current_hmo_provider_id: string | null
+          delivery_date_of_membership_ids: string | null
+          dependent_plan_type_id: string | null
+          designation_of_contact_person: string | null
+          effectivity_date: string | null
+          email_address_of_contact_person: string | null
+          expiration_date: string | null
+          hmo_provider_id: string | null
+          id: string
+          initial_contract_value: number | null
+          initial_head_count: number | null
+          is_active: boolean
+          is_approved: boolean
+          mode_of_payment_id: string | null
+          name_of_signatory: string | null
+          nature_of_business: string | null
+          orientation_date: string | null
+          previous_hmo_provider_id: string | null
+          principal_plan_type_id: string | null
+          signatory_designation: string | null
+          special_benefits: string | null
+          summary_of_benefits: string | null
+          total_premium_paid: number | null
+          total_utilization: number | null
+          updated_at: string
+          wellness_lecture_date: string | null
+        }
+        Insert: {
+          account_type_id?: string | null
+          additional_benefits?: string | null
+          agent_id?: string | null
+          annual_physical_examination_date?: string | null
+          coc_issue_date?: string | null
+          commision_rate?: number | null
+          company_address?: string | null
+          company_name: string
+          contact_number?: string | null
+          contact_person?: string | null
+          created_at?: string
+          created_by?: string | null
+          current_hmo_provider_id?: string | null
+          delivery_date_of_membership_ids?: string | null
+          dependent_plan_type_id?: string | null
+          designation_of_contact_person?: string | null
+          effectivity_date?: string | null
+          email_address_of_contact_person?: string | null
+          expiration_date?: string | null
+          hmo_provider_id?: string | null
+          id?: string
+          initial_contract_value?: number | null
+          initial_head_count?: number | null
+          is_active?: boolean
+          is_approved?: boolean
+          mode_of_payment_id?: string | null
+          name_of_signatory?: string | null
+          nature_of_business?: string | null
+          orientation_date?: string | null
+          previous_hmo_provider_id?: string | null
+          principal_plan_type_id?: string | null
+          signatory_designation?: string | null
+          special_benefits?: string | null
+          summary_of_benefits?: string | null
+          total_premium_paid?: number | null
+          total_utilization?: number | null
+          updated_at?: string
+          wellness_lecture_date?: string | null
+        }
+        Update: {
+          account_type_id?: string | null
+          additional_benefits?: string | null
+          agent_id?: string | null
+          annual_physical_examination_date?: string | null
+          coc_issue_date?: string | null
+          commision_rate?: number | null
+          company_address?: string | null
+          company_name?: string
+          contact_number?: string | null
+          contact_person?: string | null
+          created_at?: string
+          created_by?: string | null
+          current_hmo_provider_id?: string | null
+          delivery_date_of_membership_ids?: string | null
+          dependent_plan_type_id?: string | null
+          designation_of_contact_person?: string | null
+          effectivity_date?: string | null
+          email_address_of_contact_person?: string | null
+          expiration_date?: string | null
+          hmo_provider_id?: string | null
+          id?: string
+          initial_contract_value?: number | null
+          initial_head_count?: number | null
+          is_active?: boolean
+          is_approved?: boolean
+          mode_of_payment_id?: string | null
+          name_of_signatory?: string | null
+          nature_of_business?: string | null
+          orientation_date?: string | null
+          previous_hmo_provider_id?: string | null
+          principal_plan_type_id?: string | null
+          signatory_designation?: string | null
+          special_benefits?: string | null
+          summary_of_benefits?: string | null
+          total_premium_paid?: number | null
+          total_utilization?: number | null
+          updated_at?: string
+          wellness_lecture_date?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'pending_accounts_account_type_id_fkey'
+            columns: ['account_type_id']
+            isOneToOne: false
+            referencedRelation: 'account_types'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_agent_id_fkey'
+            columns: ['agent_id']
+            isOneToOne: false
+            referencedRelation: 'company_employees'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_created_by_fkey'
+            columns: ['created_by']
+            isOneToOne: false
+            referencedRelation: 'user_profiles'
+            referencedColumns: ['user_id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_current_hmo_provider_id_fkey'
+            columns: ['current_hmo_provider_id']
+            isOneToOne: false
+            referencedRelation: 'hmo_providers'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_dependent_plan_type_id_fkey'
+            columns: ['dependent_plan_type_id']
+            isOneToOne: false
+            referencedRelation: 'plan_types'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_hmo_provider_id_fkey'
+            columns: ['hmo_provider_id']
+            isOneToOne: false
+            referencedRelation: 'hmo_providers'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_mode_of_payment_id_fkey'
+            columns: ['mode_of_payment_id']
+            isOneToOne: false
+            referencedRelation: 'mode_of_payments'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_previous_hmo_provider_id_fkey'
+            columns: ['previous_hmo_provider_id']
+            isOneToOne: false
+            referencedRelation: 'hmo_providers'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_accounts_principal_plan_type_id_fkey'
+            columns: ['principal_plan_type_id']
+            isOneToOne: false
+            referencedRelation: 'plan_types'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       plan_types: {
         Row: {
           created_at: string | null
@@ -592,127 +779,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      gtrgm_compress: {
-        Args: {
-          '': unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_decompress: {
-        Args: {
-          '': unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_in: {
-        Args: {
-          '': unknown
-        }
-        Returns: unknown
-      }
-      gtrgm_options: {
-        Args: {
-          '': unknown
-        }
-        Returns: undefined
-      }
-      gtrgm_out: {
-        Args: {
-          '': unknown
-        }
-        Returns: unknown
-      }
-      search_accounts: {
-        Args: {
-          account_term: string
-          start_offset: number
-          end_offset: number
-        }
-        Returns: {
-          id: string
-          is_active: boolean
-          agent: string
-          company_name: string
-          company_address: string
-          nature_of_business: string
-          hmo_provider: string
-          previous_hmo_provider: string
-          current_hmo_provider: string
-          account_type: string
-          total_utilization: number
-          total_premium_paid: number
-          signatory_designation: string
-          contact_person: string
-          contact_number: string
-          principal_plan_type: string
-          dependent_plan_type: string
-          initial_head_count: number
-          effectivity_date: string
-          coc_issue_date: string
-          expiration_date: string
-          delivery_date_of_membership_ids: string
-          orientation_date: string
-          initial_contract_value: number
-          mode_of_payment: string
-          wellness_lecture_date: string
-          annual_physical_examination_date: string
-          commision_rate: number
-          additional_benefits: string
-          special_benefits: string
-          summary_of_benefits: string
-          name_of_signatory: string
-          designation_of_contact_person: string
-          email_address_of_contact_person: string
-          created_at: string
-          updated_at: string
-          total_count: number
-        }[]
-      }
-      search_billing_statements: {
-        Args: {
-          billing_term: string
-          start_offset: number
-          end_offset: number
-        }
-        Returns: {
-          id: string
-          account_id: string
-          account_name: string
-          mode_of_payment: string
-          mode_of_payment_id: string
-          due_date: string
-          or_number: string
-          or_date: string
-          sa_number: string
-          amount: number
-          total_contract_value: number
-          balance: number
-          billing_period: number
-          amount_billed: number
-          amount_paid: number
-          commission_rate: number
-          commission_earned: number
-          created_at: string
-          updated_at: string
-          total_count: number
-        }[]
-      }
-      set_limit: {
-        Args: {
-          '': number
-        }
-        Returns: number
-      }
-      show_limit: {
-        Args: Record<PropertyKey, never>
-        Returns: number
-      }
-      show_trgm: {
-        Args: {
-          '': string
-        }
-        Returns: string[]
-      }
+      [_ in never]: never
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20241031034911_add_pending_accounts_table.sql
+++ b/supabase/migrations/20241031034911_add_pending_accounts_table.sql
@@ -1,0 +1,127 @@
+create table "public"."pending_accounts" (
+    "id" uuid not null default gen_random_uuid(),
+    "agent_id" uuid,
+    "company_name" character varying not null,
+    "company_address" text,
+    "nature_of_business" text,
+    "hmo_provider_id" uuid,
+    "previous_hmo_provider_id" uuid,
+    "current_hmo_provider_id" uuid,
+    "account_type_id" uuid,
+    "total_utilization" double precision,
+    "total_premium_paid" double precision,
+    "signatory_designation" text,
+    "contact_person" text,
+    "contact_number" text,
+    "principal_plan_type_id" uuid,
+    "dependent_plan_type_id" uuid,
+    "initial_head_count" integer,
+    "effectivity_date" date,
+    "coc_issue_date" date,
+    "expiration_date" date,
+    "delivery_date_of_membership_ids" date,
+    "orientation_date" date,
+    "initial_contract_value" double precision,
+    "mode_of_payment_id" uuid,
+    "wellness_lecture_date" date,
+    "annual_physical_examination_date" date,
+    "commision_rate" double precision,
+    "additional_benefits" text,
+    "special_benefits" text,
+    "summary_of_benefits" text,
+    "name_of_signatory" text,
+    "designation_of_contact_person" text,
+    "email_address_of_contact_person" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now(),
+    "is_active" boolean not null default true,
+    "is_approved" boolean not null default false,
+    "created_by" uuid
+);
+
+
+alter table "public"."pending_accounts" enable row level security;
+
+CREATE UNIQUE INDEX pending_accounts_pkey ON public.pending_accounts USING btree (id);
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_pkey" PRIMARY KEY using index "pending_accounts_pkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_account_type_id_fkey" FOREIGN KEY (account_type_id) REFERENCES account_types(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_account_type_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_agent_id_fkey" FOREIGN KEY (agent_id) REFERENCES company_employees(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_agent_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_created_by_fkey" FOREIGN KEY (created_by) REFERENCES user_profiles(user_id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_created_by_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_current_hmo_provider_id_fkey" FOREIGN KEY (current_hmo_provider_id) REFERENCES hmo_providers(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_current_hmo_provider_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_dependent_plan_type_id_fkey" FOREIGN KEY (dependent_plan_type_id) REFERENCES plan_types(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_dependent_plan_type_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_hmo_provider_id_fkey" FOREIGN KEY (hmo_provider_id) REFERENCES hmo_providers(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_hmo_provider_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_mode_of_payment_id_fkey" FOREIGN KEY (mode_of_payment_id) REFERENCES mode_of_payments(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_mode_of_payment_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_previous_hmo_provider_id_fkey" FOREIGN KEY (previous_hmo_provider_id) REFERENCES hmo_providers(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_previous_hmo_provider_id_fkey";
+
+alter table "public"."pending_accounts" add constraint "pending_accounts_principal_plan_type_id_fkey" FOREIGN KEY (principal_plan_type_id) REFERENCES plan_types(id) not valid;
+
+alter table "public"."pending_accounts" validate constraint "pending_accounts_principal_plan_type_id_fkey";
+
+grant delete on table "public"."pending_accounts" to "anon";
+
+grant insert on table "public"."pending_accounts" to "anon";
+
+grant references on table "public"."pending_accounts" to "anon";
+
+grant select on table "public"."pending_accounts" to "anon";
+
+grant trigger on table "public"."pending_accounts" to "anon";
+
+grant truncate on table "public"."pending_accounts" to "anon";
+
+grant update on table "public"."pending_accounts" to "anon";
+
+grant delete on table "public"."pending_accounts" to "authenticated";
+
+grant insert on table "public"."pending_accounts" to "authenticated";
+
+grant references on table "public"."pending_accounts" to "authenticated";
+
+grant select on table "public"."pending_accounts" to "authenticated";
+
+grant trigger on table "public"."pending_accounts" to "authenticated";
+
+grant truncate on table "public"."pending_accounts" to "authenticated";
+
+grant update on table "public"."pending_accounts" to "authenticated";
+
+grant delete on table "public"."pending_accounts" to "service_role";
+
+grant insert on table "public"."pending_accounts" to "service_role";
+
+grant references on table "public"."pending_accounts" to "service_role";
+
+grant select on table "public"."pending_accounts" to "service_role";
+
+grant trigger on table "public"."pending_accounts" to "service_role";
+
+grant truncate on table "public"."pending_accounts" to "service_role";
+
+grant update on table "public"."pending_accounts" to "service_role";
+
+

--- a/supabase/migrations/20241031041800_add_rls_to_pending_accounts_table.sql
+++ b/supabase/migrations/20241031041800_add_rls_to_pending_accounts_table.sql
@@ -1,0 +1,37 @@
+create policy "Enable ALL access for admin"
+on "public"."pending_accounts"
+as restrictive
+for all
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text]))))))));
+
+
+create policy "Enable insert based on created_by"
+on "public"."pending_accounts"
+as restrictive
+for insert
+to authenticated
+with check ((( SELECT auth.uid() AS uid) = created_by));
+
+
+create policy "Enable select for users based on created_by"
+on "public"."pending_accounts"
+as restrictive
+for select
+to authenticated
+using ((( SELECT auth.uid() AS uid) = created_by));
+
+
+create policy "Enable update access based on created_by"
+on "public"."pending_accounts"
+as permissive
+for update
+to authenticated
+using ((( SELECT auth.uid() AS uid) = created_by));
+
+
+


### PR DESCRIPTION
### TL;DR
Added a new `pending_accounts` table with row-level security policies to manage account approval workflows.

### What changed?
- Created a new `pending_accounts` table with fields matching the existing accounts structure
- Added foreign key relationships to related tables (account_types, company_employees, etc.)
- Implemented row-level security policies:
  - Admin users have full access
  - Regular users can only insert, select, and update records they created
- Added timestamps and approval status tracking fields
- Granted necessary permissions to anon, authenticated, and service role users

### How to test?
1. Create a new pending account as a non-admin user
2. Verify you can only view and edit your own pending accounts
3. Login as admin and confirm full access to all pending accounts
4. Attempt to access pending accounts as different user roles to verify RLS policies
5. Test foreign key constraints by referencing invalid IDs

### Why make this change?
To implement a proper approval workflow for new accounts, allowing users to create draft accounts that require admin review before being officially added to the system. This improves data quality and provides better control over account creation.