### PR TITLE
TIM-568 feat(accounts): add submission request list

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/data-table.tsx
@@ -37,6 +37,7 @@ import { useEffect, useState } from 'react'
 import AccountsProvider from './accounts-provider'
 import AddAccountButton from './add-account-button'
 import getAccounts from '@/queries/get-accounts'
+import AccountRequest from '@/app/(dashboard)/(home)/accounts/request/account-request'
 
 interface IData {
   id: string
@@ -154,7 +155,10 @@ const DataTable = <TData extends IData, TValue>({
             </div>
           </div>
         </PageHeader>
-        <TableViewOptions table={table} />
+        <div className="flex flex-row">
+          <AccountRequest />
+          <TableViewOptions table={table} />
+        </div>
         <div className="h-full bg-card">
           <div className="rounded-md border">
             <Table>

--- a/src/app/(dashboard)/(home)/accounts/request/account-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/request/account-request-list-item.tsx
@@ -1,0 +1,64 @@
+import DeleteRequest from '@/app/(dashboard)/(home)/accounts/request/delete-request'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Tables } from '@/types/database.types'
+import { formatDistanceToNow } from 'date-fns'
+import { FC } from 'react'
+
+interface AccountRequestListItemProps {
+  pendingAccount: Tables<'pending_accounts'>
+}
+
+const AccountRequestListItem: FC<AccountRequestListItemProps> = ({
+  pendingAccount,
+}) => {
+  const badgeIcon = () => {
+    switch (pendingAccount.operation_type) {
+      case 'insert':
+        return (
+          <Badge
+            variant="outline"
+            className="w-fit bg-green-100 text-green-500"
+          >
+            Add
+          </Badge>
+        )
+      case 'update':
+        return (
+          <Badge
+            variant="outline"
+            className="w-fit bg-yellow-100 text-yellow-500"
+          >
+            Edit
+          </Badge>
+        )
+      case 'delete':
+        return (
+          <Badge
+            variant="destructive"
+            className="w-fit bg-red-100 text-red-500"
+          >
+            Delete
+          </Badge>
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-2 items-center gap-y-2 px-2 py-6">
+      {badgeIcon()}
+      <span className="ml-auto w-fit text-sm text-muted-foreground">
+        {formatDistanceToNow(new Date(pendingAccount.created_at), {
+          addSuffix: true,
+        })}
+      </span>
+
+      <p className="text-sm font-medium">{pendingAccount.company_name}</p>
+      <DeleteRequest pendingAccountId={pendingAccount.id} />
+    </div>
+  )
+}
+
+export default AccountRequestListItem

--- a/src/app/(dashboard)/(home)/accounts/request/account-request-list.tsx
+++ b/src/app/(dashboard)/(home)/accounts/request/account-request-list.tsx
@@ -1,0 +1,22 @@
+import AccountRequestListItem from '@/app/(dashboard)/(home)/accounts/request/account-request-list-item'
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const AccountRequestList = () => {
+  const supabase = createBrowserClient()
+
+  const { data: pendingAccounts } = useQuery(getPendingAccounts(supabase))
+  return (
+    <div className="grid grid-cols-1 divide-y">
+      {pendingAccounts?.map((pendingAccount) => (
+        <AccountRequestListItem
+          key={pendingAccount.id}
+          pendingAccount={pendingAccount}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default AccountRequestList

--- a/src/app/(dashboard)/(home)/accounts/request/account-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/request/account-request.tsx
@@ -1,0 +1,47 @@
+'use client'
+import AccountRequestList from '@/app/(dashboard)/(home)/accounts/request/account-request-list'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { useState } from 'react'
+
+const AccountRequest = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const supabase = createBrowserClient()
+
+  const { count } = useQuery(getPendingAccounts(supabase))
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild={true}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex h-8 w-full rounded-none"
+        >
+          {count} Requests
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Submission Requests</DialogTitle>
+          <DialogDescription>
+            View and manage account requests and submissions
+          </DialogDescription>
+        </DialogHeader>
+        <AccountRequestList />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AccountRequest

--- a/src/app/(dashboard)/(home)/accounts/request/delete-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/request/delete-request.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+import { createBrowserClient } from '@/utils/supabase'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { Loader2 } from 'lucide-react'
+import { FC, useState } from 'react'
+
+interface DeleteRequestProps {
+  pendingAccountId: string
+}
+const DeleteRequest: FC<DeleteRequestProps> = ({ pendingAccountId }) => {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const { toast } = useToast()
+
+  const supabase = createBrowserClient()
+  const { mutate: updatePendingAccount, isPending } = useUpdateMutation(
+    // @ts-ignore
+    supabase.from('pending_accounts'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Request deleted!',
+          description: 'Successfully deleted request',
+        })
+      },
+      onError: (err: any) => {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: err.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = () => {
+    updatePendingAccount({ id: pendingAccountId, is_active: false })
+  }
+
+  return (
+    <>
+      {confirmDelete ? (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          disabled={isPending}
+          onClick={handleDelete}
+        >
+          {isPending ? <Loader2 className="animate-spin" /> : 'Are you sure?'}
+        </Button>
+      ) : (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          onClick={() => setConfirmDelete(true)}
+        >
+          Cancel
+        </Button>
+      )}
+    </>
+  )
+}
+
+export default DeleteRequest

--- a/src/components/table-view-options.tsx
+++ b/src/components/table-view-options.tsx
@@ -22,7 +22,11 @@ export const TableViewOptions = <TData,>({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="flex h-8">
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex h-8 w-fit rounded-none"
+        >
           <MixerHorizontalIcon className="mr-2 h-4 w-4" />
           View
         </Button>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/tailwind'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/queries/get-pending-accounts.ts
+++ b/src/queries/get-pending-accounts.ts
@@ -1,0 +1,62 @@
+import { TypedSupabaseClient } from '@/types/typedSupabaseClient'
+
+const getPendingAccounts = (supabase: TypedSupabaseClient) => {
+  return supabase
+    .from('pending_accounts')
+    .select(
+      `
+    id,
+    agent_id,
+    company_name,
+    company_address,
+    nature_of_business,
+    hmo_provider_id,
+    previous_hmo_provider_id,
+    current_hmo_provider_id,
+    account_type_id,
+    total_utilization,
+    total_premium_paid,
+    signatory_designation,
+    contact_person,
+    contact_number,
+    principal_plan_type_id,
+    dependent_plan_type_id,
+    initial_head_count,
+    effectivity_date,
+    coc_issue_date,
+    expiration_date,
+    delivery_date_of_membership_ids,
+    orientation_date,
+    initial_contract_value,
+    mode_of_payment_id,
+    wellness_lecture_date,
+    annual_physical_examination_date,
+    commision_rate,
+    additional_benefits,
+    special_benefits,
+    summary_of_benefits,
+    name_of_signatory,
+    designation_of_contact_person,
+    email_address_of_contact_person,
+    created_at,
+    updated_at,
+    is_active,
+    is_approved,
+    created_by,
+    account_id,
+    operation_type
+  `,
+      {
+        count: 'exact',
+      },
+    )
+    .eq('is_approved', 'false')
+    .eq('is_active', true)
+    .order('created_at', { ascending: false })
+    .throwOnError()
+
+  // we don't need to check for the created_by column
+  //since RLS already handle this for us
+}
+
+export default getPendingAccounts

--- a/supabase/migrations/20241031094042_add_update_rls_on_pending_accounts_table.sql
+++ b/supabase/migrations/20241031094042_add_update_rls_on_pending_accounts_table.sql
@@ -1,0 +1,41 @@
+create policy "Enable read access based on created_by"
+on "public"."pending_accounts"
+as permissive
+for select
+to public
+using ((( SELECT auth.uid() AS uid) = created_by));
+
+
+create policy "Enable read access for admin"
+on "public"."pending_accounts"
+as permissive
+for select
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update access for admin"
+on "public"."pending_accounts"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update for users based on created_by"
+on "public"."pending_accounts"
+as permissive
+for update
+to public
+using ((( SELECT auth.uid() AS uid) = created_by));
+
+
+


### PR DESCRIPTION
### TL;DR
Added a new account request management system to track and handle pending account submissions.

### What changed?
- Added a new "Requests" button in the accounts table header showing the count of pending requests
- Created a dialog component to display pending account submissions
- Implemented request list items with badges indicating operation type (Add/Edit/Delete)
- Added ability to cancel/delete pending requests
- Set up RLS policies for pending accounts table to manage access control
- Added new database queries to fetch pending account data

### How to test?
1. Navigate to the accounts page
2. Click on the "Requests" button in the table header
3. Verify pending requests are displayed with appropriate badges
4. Test canceling a request:
   - Click "Cancel" on a request
   - Confirm deletion when prompted
   - Verify request is removed from the list
5. Verify access controls:
   - Test as regular user to ensure you can only see your requests
   - Test as admin to verify full access to all requests

### Why make this change?
To provide a structured way to manage and track account-related requests before they are approved and implemented in the system. This helps maintain data integrity and provides better oversight of account changes.