### PR TITLE
feat(admin): add approval request table and management interface

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/approval-request-data-table-row.tsx
+++ b/src/app/(dashboard)/admin/approval-request/approval-request-data-table-row.tsx
@@ -1,0 +1,44 @@
+import { TableCell, TableRow } from '@/components/ui/table'
+import { Tables } from '@/types/database.types'
+import { ColumnDef, Table, flexRender } from '@tanstack/react-table'
+import { useState } from 'react'
+
+interface ApprovalRequestDataTableRowProps<TData> {
+  table: Table<TData>
+  columns: ColumnDef<TData>[]
+}
+
+const ApprovalRequestDataTableRow = <TData,>({
+  table,
+  columns,
+}: ApprovalRequestDataTableRowProps<TData>) => {
+  const handleOnClick = (originalData: TData) => {}
+
+  return (
+    <>
+      {table.getRowModel().rows?.length ? (
+        table.getRowModel().rows.map((row) => (
+          <TableRow
+            key={row.id}
+            className="cursor-pointer hover:!bg-muted"
+            onClick={() => handleOnClick(row.original)}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <TableCell key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))
+      ) : (
+        <TableRow>
+          <TableCell colSpan={columns.length} className="h-16 text-center">
+            No results.
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+
+export default ApprovalRequestDataTableRow

--- a/src/app/(dashboard)/admin/approval-request/approval-request-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/approval-request-table.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import {
+  PageDescription,
+  PageHeader,
+  PageTitle,
+} from '@/components/page-header'
+import TablePagination from '@/components/table-pagination'
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useState } from 'react'
+
+import TableSearch from '@/components/table-search'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useTableContext } from '@/providers/TableProvider'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
+import getBillingStatements from '@/queries/get-billing-statements'
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import approvalRequestColumns from '@/app/(dashboard)/admin/approval-request/approval-rerquest-columns'
+import ApprovalRequestDataTableRow from '@/app/(dashboard)/admin/approval-request/approval-request-data-table-row'
+
+const ApprovalRequestTable = () => {
+  const supabase = createBrowserClient()
+  const { data, count, isPending } = useQuery(
+    getPendingAccounts(supabase, 'desc'),
+  )
+
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [globalFilter, setGlobalFilter] = useState<any>('')
+
+  const table = useReactTable({
+    data: data || [],
+    columns: approvalRequestColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: 'includesString',
+    state: {
+      sorting,
+      globalFilter,
+    },
+  })
+
+  return (
+    <div className="flex flex-col">
+      <PageHeader>
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:justify-between">
+          <div>
+            <PageTitle>Approval Requests</PageTitle>
+            {isPending ? (
+              <Skeleton className="h-4 w-20" />
+            ) : (
+              <PageDescription>{count} approval requests</PageDescription>
+            )}
+          </div>
+          <div>
+            <TableSearch table={table} placeholder="Search requests" />
+          </div>
+        </div>
+      </PageHeader>
+
+      <div className="flex h-full flex-col justify-between bg-card">
+        <div className="h-full rounded-md border">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              <ApprovalRequestDataTableRow
+                table={table}
+                columns={approvalRequestColumns}
+              />
+            </TableBody>
+          </Table>
+        </div>
+        <TablePagination table={table} />
+      </div>
+    </div>
+  )
+}
+
+export default ApprovalRequestTable

--- a/src/app/(dashboard)/admin/approval-request/approval-rerquest-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/approval-rerquest-columns.tsx
@@ -1,0 +1,52 @@
+import { Tables } from '@/types/database.types'
+import { ColumnDef } from '@tanstack/react-table'
+import TableHeader from '@/components/table-header'
+import { formatDate, formatDistanceToNow } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { Check, X } from 'lucide-react'
+
+const approvalRequestColumns: ColumnDef<Tables<'pending_accounts'>>[] = [
+  {
+    accessorKey: 'operation_type',
+    header: ({ column }) => <TableHeader column={column} title="Action" />,
+    cell: ({ row }) => {
+      return <div className="capitalize">{row.original.operation_type}</div>
+    },
+  },
+  {
+    accessorKey: 'company_name',
+    header: ({ column }) => <TableHeader column={column} title="Account" />,
+  },
+  {
+    accessorKey: 'created_at',
+    header: ({ column }) => (
+      <TableHeader column={column} title="Requested At" />
+    ),
+    cell: ({ row }) => {
+      return (
+        <div>
+          {formatDistanceToNow(new Date(row.original.created_at), {
+            addSuffix: true,
+          })}
+        </div>
+      )
+    },
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      return (
+        <div className="flex items-center gap-2">
+          <Button size={'icon'} variant="ghost" className="">
+            <Check className="h-4 w-4" />
+          </Button>
+          <Button size={'icon'} variant="ghost" className="">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )
+    },
+  },
+]
+
+export default approvalRequestColumns

--- a/src/app/(dashboard)/admin/approval-request/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/page.tsx
@@ -1,0 +1,26 @@
+'use server'
+
+import ApprovalRequestTable from '@/app/(dashboard)/admin/approval-request/approval-request-table'
+import getPendingAccounts from '@/queries/get-pending-accounts'
+import { createServerClient } from '@/utils/supabase'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query'
+import { cookies } from 'next/headers'
+
+const ApprovalRequestPage = async () => {
+  const supabase = createServerClient(cookies())
+  const queryClient = new QueryClient()
+  await prefetchQuery(queryClient, getPendingAccounts(supabase, 'desc'))
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ApprovalRequestTable />
+    </HydrationBoundary>
+  )
+}
+
+export default ApprovalRequestPage

--- a/src/components/layout/admin-navigation.tsx
+++ b/src/components/layout/admin-navigation.tsx
@@ -1,4 +1,4 @@
-import { BookType, FileText, Users } from 'lucide-react'
+import { BookType, FileText, ListTodo, Users } from 'lucide-react'
 import NavigationItem from './navigation-item'
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
@@ -17,6 +17,11 @@ const AdminNavigation = async () => {
         <span className="text-[11px] text-white/50">Administrator tools</span>
       </div>
       <div className="space-y-1">
+        <NavigationItem
+          title="Approval Requests"
+          href="/admin/approval-request"
+          icon={<ListTodo className="h-6 w-6 group-hover:text-white" />}
+        />
         <NavigationItem
           title="Users"
           href="/admin/users"

--- a/src/components/table-search.tsx
+++ b/src/components/table-search.tsx
@@ -5,15 +5,19 @@ import { Search } from 'lucide-react'
 
 interface TableSearchProps<TData> {
   table: Table<TData>
+  placeholder?: string
 }
 
-const TableSearch = <TData,>({ table }: TableSearchProps<TData>) => {
+const TableSearch = <TData,>({
+  table,
+  placeholder = 'Search accounts',
+}: TableSearchProps<TData>) => {
   return (
     <div className="relative">
       <Search className="absolute left-3.5 top-3.5 h-5 w-5 text-[#94a3b8]" />
       <Input
         className="max-w-xs rounded-full pl-10"
-        placeholder="Search accounts"
+        placeholder={placeholder}
         value={table.getState().globalFilter}
         onChange={(e) => table.setGlobalFilter(e.target.value)}
       />

--- a/src/queries/get-pending-accounts.ts
+++ b/src/queries/get-pending-accounts.ts
@@ -1,6 +1,9 @@
 import { TypedSupabaseClient } from '@/types/typedSupabaseClient'
 
-const getPendingAccounts = (supabase: TypedSupabaseClient) => {
+const getPendingAccounts = (
+  supabase: TypedSupabaseClient,
+  sort: 'asc' | 'desc' = 'desc',
+) => {
   return supabase
     .from('pending_accounts')
     .select(
@@ -52,7 +55,7 @@ const getPendingAccounts = (supabase: TypedSupabaseClient) => {
     )
     .eq('is_approved', 'false')
     .eq('is_active', true)
-    .order('created_at', { ascending: false })
+    .order('created_at', { ascending: sort === 'asc' })
     .throwOnError()
 
   // we don't need to check for the created_by column


### PR DESCRIPTION
### TL;DR
Added a new approval request management interface for administrators to review and process pending account requests.

### What changed?
- Created a new approval request table view with sorting and filtering capabilities
- Added approval request columns showing action type, account name, and request timestamp
- Implemented approve/reject action buttons for each request
- Added a new "Approval Requests" navigation item in the admin sidebar
- Enhanced the table search component to accept custom placeholder text
- Updated the pending accounts query to support customizable sort order

### How to test?
1. Log in as an administrator
2. Navigate to the new "Approval Requests" section in the admin sidebar
3. Verify the table displays pending account requests with correct information
4. Test search functionality using the search bar
5. Confirm sorting works by clicking column headers
6. Verify approve/reject buttons are present for each request

### Why make this change?
To provide administrators with a dedicated interface for managing account approval requests, streamlining the process of reviewing and responding to new account registrations and modifications.