### PR TITLE
feat(accounts): add company name uniqueness validation

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
@@ -94,6 +94,34 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
         } = await supabase.auth.getUser()
         if (!user) return
 
+        // check if company_name already exists in pending_accounts
+        const { data: existingAccount } = await supabase
+          .from('pending_accounts')
+          .select('company_name')
+          .eq('company_name', data.company_name)
+          .single()
+
+        if (existingAccount) {
+          form.setError('company_name', {
+            message: 'Account already exists',
+          })
+          return
+        }
+
+        // check if company_name already exists in accounts
+        const { data: existingAccountInAccounts } = await supabase
+          .from('accounts')
+          .select('company_name')
+          .eq('company_name', data.company_name)
+          .single()
+
+        if (existingAccountInAccounts) {
+          form.setError('company_name', {
+            message: 'Account already exists',
+          })
+          return
+        }
+
         await mutateAsync([
           {
             company_name: data.company_name,

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -64,7 +64,7 @@ export type Database = {
           coc_issue_date: string | null
           commision_rate: number | null
           company_address: string | null
-          company_name: string | null
+          company_name: string
           contact_number: string | null
           contact_person: string | null
           created_at: string
@@ -102,7 +102,7 @@ export type Database = {
           coc_issue_date?: string | null
           commision_rate?: number | null
           company_address?: string | null
-          company_name?: string | null
+          company_name: string
           contact_number?: string | null
           contact_person?: string | null
           created_at?: string
@@ -140,7 +140,7 @@ export type Database = {
           coc_issue_date?: string | null
           commision_rate?: number | null
           company_address?: string | null
-          company_name?: string | null
+          company_name?: string
           contact_number?: string | null
           contact_person?: string | null
           created_at?: string

--- a/supabase/migrations/20241102150409_change_company_name_to_be_unique.sql
+++ b/supabase/migrations/20241102150409_change_company_name_to_be_unique.sql
@@ -1,0 +1,9 @@
+alter table "public"."accounts" alter column "company_name" set not null;
+
+alter table "public"."accounts" alter column "company_name" set data type text using "company_name"::text;
+
+CREATE UNIQUE INDEX accounts_company_name_key ON public.accounts USING btree (company_name);
+
+alter table "public"."accounts" add constraint "accounts_company_name_key" UNIQUE using index "accounts_company_name_key";
+
+


### PR DESCRIPTION
### TL;DR
Added validation to prevent duplicate company names when creating new accounts.

### What changed?
Added checks against both `pending_accounts` and `accounts` tables to verify if a company name already exists before allowing account creation. If a duplicate is found, an error message is displayed to the user.

### How to test?
1. Attempt to create a new account with a company name that already exists in the `pending_accounts` table
2. Verify that an error message "Account already exists" appears
3. Attempt to create a new account with a company name that already exists in the `accounts` table
4. Verify that an error message "Account already exists" appears
5. Create an account with a unique company name and verify it succeeds

### Why make this change?
To prevent duplicate company entries in the system and maintain data integrity across both pending and active accounts.