### PR TITLE
feat(accounts): implement pending accounts approval workflow

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -16,6 +16,7 @@ import { createBrowserClient } from '@/utils/supabase'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { maskitoTransform } from '@maskito/core'
 import {
+  useInsertMutation,
   useQuery,
   useUpdateMutation,
 } from '@supabase-cache-helpers/postgrest-react-query'
@@ -116,11 +117,11 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
     },
   })
 
-  const { mutateAsync } = useUpdateMutation(
+  const { mutateAsync } = useInsertMutation(
     //@ts-ignore
-    supabase.from('accounts'),
+    supabase.from('pending_accounts'),
     ['id'],
-    'id',
+    null,
     {
       onSuccess: () => {
         setEditMode(false)
@@ -138,42 +139,61 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
   const onSubmitHandler = useCallback<FormEventHandler<HTMLFormElement>>(
     (e) => {
       form.handleSubmit(async (data) => {
-        await mutateAsync({
-          id: companyId,
-          company_name: data.company_name,
-          company_address: data.company_address,
-          initial_head_count: data.initial_head_count,
-          nature_of_business: data.nature_of_business,
-          contact_person: data.contact_person,
-          contact_number: data.contact_number,
-          signatory_designation: data.signatory_designation,
-          name_of_signatory: data.name_of_signatory,
-          designation_of_contact_person: data.designation_of_contact_person,
-          email_address_of_contact_person: data.email_address_of_contact_person,
-          account_type_id: data?.account_type_id,
-          agent_id: data.agent_id,
-          is_active: data.is_active,
-          commision_rate: data.commision_rate,
-          hmo_provider_id: data?.hmo_provider_id,
-          previous_hmo_provider_id: data?.previous_hmo_provider_id,
-          current_hmo_provider_id: data?.current_hmo_provider_id,
-          principal_plan_type_id: data?.principal_plan_type_id,
-          dependent_plan_type_id: data?.dependent_plan_type_id,
-          total_utilization: data.total_utilization,
-          total_premium_paid: data.total_premium_paid,
-          additional_benefits: data.additional_benefits,
-          special_benefits: data.special_benefits,
-          initial_contract_value: data.initial_contract_value,
-          mode_of_payment_id: data?.mode_of_payment_id,
-          expiration_date: data.expiration_date,
-          effectivity_date: data.effectivity_date,
-          coc_issue_date: data.coc_issue_date,
-          delivery_date_of_membership_ids: data.delivery_date_of_membership_ids,
-          orientation_date: data.orientation_date,
-          wellness_lecture_date: data.wellness_lecture_date,
-          annual_physical_examination_date:
-            data.annual_physical_examination_date,
-        })
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+
+        if (!user) {
+          toast({
+            title: 'Something went wrong',
+            description: 'Please try again',
+            variant: 'destructive',
+          })
+          return
+        }
+
+        await mutateAsync([
+          {
+            account_id: companyId,
+            company_name: data.company_name,
+            company_address: data.company_address,
+            initial_head_count: data.initial_head_count,
+            nature_of_business: data.nature_of_business,
+            contact_person: data.contact_person,
+            contact_number: data.contact_number,
+            signatory_designation: data.signatory_designation,
+            name_of_signatory: data.name_of_signatory,
+            designation_of_contact_person: data.designation_of_contact_person,
+            email_address_of_contact_person:
+              data.email_address_of_contact_person,
+            account_type_id: data?.account_type_id,
+            agent_id: data.agent_id,
+            is_active: data.is_active,
+            commision_rate: data.commision_rate,
+            hmo_provider_id: data?.hmo_provider_id,
+            previous_hmo_provider_id: data?.previous_hmo_provider_id,
+            current_hmo_provider_id: data?.current_hmo_provider_id,
+            principal_plan_type_id: data?.principal_plan_type_id,
+            dependent_plan_type_id: data?.dependent_plan_type_id,
+            total_utilization: data.total_utilization,
+            total_premium_paid: data.total_premium_paid,
+            additional_benefits: data.additional_benefits,
+            special_benefits: data.special_benefits,
+            initial_contract_value: data.initial_contract_value,
+            mode_of_payment_id: data?.mode_of_payment_id,
+            expiration_date: data.expiration_date,
+            effectivity_date: data.effectivity_date,
+            coc_issue_date: data.coc_issue_date,
+            delivery_date_of_membership_ids:
+              data.delivery_date_of_membership_ids,
+            orientation_date: data.orientation_date,
+            wellness_lecture_date: data.wellness_lecture_date,
+            annual_physical_examination_date:
+              data.annual_physical_examination_date,
+            created_by: user.id,
+            operation_type: 'update',
+          },
+        ])
       })(e)
     },
     [companyId, form, mutateAsync],

--- a/src/app/(dashboard)/admin/approval-request/accounts/accounts-approval-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/accounts-approval-columns.tsx
@@ -1,4 +1,5 @@
 import { useApprovalRequestContext } from '@/app/(dashboard)/admin/approval-request/accounts/approval-request-provider'
+import OperationBadge from '@/app/(dashboard)/admin/approval-request/accounts/modal/operation-badge'
 import TableHeader from '@/components/table-header'
 import { Button } from '@/components/ui/button'
 import { Tables } from '@/types/database.types'
@@ -11,6 +12,9 @@ const accountsApprovalColumns: ColumnDef<Tables<'pending_accounts'>>[] = [
     accessorKey: 'operation_type',
     header: ({ column }) => <TableHeader column={column} title="Action" />,
     accessorFn: (row) => row.operation_type,
+    cell: ({ row }) => (
+      <OperationBadge operationType={row.original.operation_type} />
+    ),
   },
   {
     accessorKey: 'company_name',

--- a/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
@@ -2,8 +2,8 @@ import { useApprovalRequestContext } from '@/app/(dashboard)/admin/approval-requ
 import { useToast } from '@/components/ui/use-toast'
 import { createBrowserClient } from '@/utils/supabase'
 import {
-  useInsertMutation,
   useUpdateMutation,
+  useUpsertMutation,
 } from '@supabase-cache-helpers/postgrest-react-query'
 import { FC, ReactNode, useEffect } from 'react'
 
@@ -22,10 +22,10 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
     useApprovalRequestContext()
 
   const {
-    mutateAsync: insertAccount,
-    isError: isInsertAccountError,
-    isPending: isInsertingAccount,
-  } = useInsertMutation(
+    mutateAsync: upsertAccount,
+    isError: isUpsertAccountError,
+    isPending: isUpsertingAccount,
+  } = useUpsertMutation(
     // @ts-expect-error
     supabase.from('accounts'),
     ['id'],
@@ -66,13 +66,14 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
   )
 
   const handleClick = async () => {
-    if (!selectedData?.id) throw new Error('ID is required')
+    if (!selectedData) throw new Error('Selected data is required')
 
     // Only insert account if action is approve
     if (action === 'approve') {
       // Insert account
-      await insertAccount([
+      await upsertAccount([
         {
+          id: selectedData.account_id,
           company_name: selectedData.company_name,
           is_active: selectedData.is_active,
           agent_id: (selectedData as any).agent?.user_id,
@@ -113,7 +114,7 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
             selectedData.email_address_of_contact_person,
         },
       ])
-      if (isInsertAccountError)
+      if (isUpsertAccountError)
         throw new Error('Error updating pending account')
     }
 
@@ -126,9 +127,9 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
   }
 
   useEffect(() => {
-    if (isInsertingAccount || isUpdatingPendingAccount) setIsLoading(true)
+    if (isUpsertingAccount || isUpdatingPendingAccount) setIsLoading(true)
     else setIsLoading(false)
-  }, [isInsertingAccount, isUpdatingPendingAccount, setIsLoading])
+  }, [isUpsertingAccount, isUpdatingPendingAccount, setIsLoading])
 
   return <div onClick={handleClick}>{children}</div>
 }


### PR DESCRIPTION
### TL;DR
Implemented approval workflow for company profile updates with pending changes system

### What changed?
- Modified company profile updates to create pending changes instead of direct updates
- Added operation type badges to display pending action types
- Changed account updates to use upsert instead of direct updates
- Implemented user tracking for pending changes
- Enhanced approval request handling with proper account ID mapping

### How to test?
1. Edit a company profile and submit changes
2. Verify changes appear in the approval request queue
3. Test both approve and reject actions on pending changes
4. Confirm approved changes are reflected in the main account
5. Verify operation type badges display correctly
6. Check that user tracking is working for pending changes

### Why make this change?
To implement a proper approval workflow for company profile modifications, ensuring changes are reviewed before being applied to the main system. This adds an additional layer of control and accountability to the profile update process.