### PR TITLE
feat(company): add pending edit request handling for company details

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-button.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import EditPendingRequest from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/edit-pending-request'
 import { Button } from '@/components/ui/button'
+import { createBrowserClient } from '@/utils/supabase'
 import { Pencil } from 'lucide-react'
-import { FC } from 'react'
+import { FC, useState, useCallback, useMemo } from 'react'
 
 interface Props {
   role: string | null
@@ -11,13 +14,34 @@ interface Props {
 
 const CompanyEditButton: FC<Props> = ({ role }) => {
   const { editMode, setEditMode } = useCompanyEditContext()
-  const allowedRole = [
-    'admin',
-    'marketing',
-    'finance',
-    'under-writing',
-    'after-sales',
-  ]
+  const { accountId } = useCompanyContext()
+  const [isEditPendingRequestOpen, setIsEditPendingRequestOpen] =
+    useState(false)
+  const [pendingRequestId, setPendingRequestId] = useState('')
+
+  const allowedRole = useMemo(
+    () => ['admin', 'marketing', 'finance', 'under-writing', 'after-sales'],
+    [],
+  )
+
+  const supabase = createBrowserClient()
+
+  const handleClick = useCallback(async () => {
+    const { data } = await supabase
+      .from('pending_accounts')
+      .select('id')
+      .eq('account_id', accountId)
+      .eq('is_active', true)
+      .eq('is_approved', false)
+      .single()
+
+    if (data) {
+      setIsEditPendingRequestOpen(true)
+      setPendingRequestId(data.id)
+    } else {
+      setEditMode(true)
+    }
+  }, [accountId, setEditMode, supabase])
 
   if (!role || !allowedRole.includes(role)) {
     return null
@@ -26,13 +50,15 @@ const CompanyEditButton: FC<Props> = ({ role }) => {
   return (
     <>
       {!editMode && (
-        <Button
-          className="w-full gap-2 md:max-w-xs"
-          onClick={() => setEditMode(true)}
-        >
+        <Button className="w-full gap-2 md:max-w-xs" onClick={handleClick}>
           <Pencil /> <span> Edit Company Details </span>
         </Button>
       )}
+      <EditPendingRequest
+        isOpen={isEditPendingRequestOpen}
+        onClose={() => setIsEditPendingRequestOpen(false)}
+        pendingRequestId={pendingRequestId}
+      />
     </>
   )
 }

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/edit-pending-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/edit-pending-request.tsx
@@ -1,0 +1,90 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { useToast } from '@/components/ui/use-toast'
+import { createBrowserClient } from '@/utils/supabase'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { Loader2, Trash } from 'lucide-react'
+import { FC } from 'react'
+
+interface EditPendingRequestProps {
+  isOpen: boolean
+  onClose: () => void
+  pendingRequestId: string
+}
+
+const EditPendingRequest: FC<EditPendingRequestProps> = ({
+  isOpen,
+  onClose,
+  pendingRequestId,
+}) => {
+  const supabase = createBrowserClient()
+  const { toast } = useToast()
+
+  const { mutateAsync, isPending } = useUpdateMutation(
+    // @ts-expect-error
+    supabase.from('pending_accounts'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Request deleted!',
+          description: 'Successfully deleted request',
+        })
+        onClose()
+      },
+      onError: (err: any) => {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: err.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = () => {
+    mutateAsync({ id: pendingRequestId, is_active: false })
+  }
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Pending Request Notice</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your request is awaiting admin approval. If you wish to make further
+            changes to the company details, you may delete the current request,
+            but{' '}
+            <span className="font-bold">all changes will be discarded.</span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleDelete} disabled={isPending}>
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                <Trash className="mr-2 h-4 w-4" /> Delete Request
+              </>
+            )}
+          </AlertDialogCancel>
+          <AlertDialogAction disabled={isPending}>
+            Wait for Approval
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default EditPendingRequest


### PR DESCRIPTION
### TL;DR
Added a pending request check before allowing company profile edits

### What changed?
- Enhanced the CompanyEditButton to check for existing pending requests
- Created a new EditPendingRequest dialog component
- Added functionality to delete pending requests
- Implemented user notifications for request actions

### How to test?
1. Log in as a user with appropriate role permissions
2. Navigate to a company profile
3. Click the "Edit Company Details" button
4. If there's a pending request:
   - Verify the pending request dialog appears
   - Test deleting the request
   - Confirm toast notifications work
5. If no pending request:
   - Verify edit mode activates normally

### Why make this change?
To prevent multiple concurrent edit requests and maintain better control over company profile changes by ensuring only one pending request exists at a time. This improves the admin approval workflow and provides clear feedback to users about their pending changes.