### PR TITLE
feat(accounts): implement pending delete request workflow

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -124,6 +124,11 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
     null,
     {
       onSuccess: () => {
+        toast({
+          title: 'Edit Request Submitted',
+          description:
+            'Your request to edit the company details has been submitted successfully and is awaiting approval.',
+        })
         setEditMode(false)
       },
       onError: (error) => {

--- a/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
@@ -73,9 +73,9 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
       // Insert account
       await upsertAccount([
         {
-          id: selectedData.account_id,
+          ...(selectedData.account_id && { id: selectedData.account_id }),
           company_name: selectedData.company_name,
-          is_active: selectedData.is_active,
+          is_active: selectedData.is_delete_account ? false : true, // if delete account is true, then is_active is false
           agent_id: (selectedData as any).agent?.user_id,
           company_address: selectedData.company_address,
           nature_of_business: selectedData.nature_of_business,

--- a/src/queries/get-pending-accounts.ts
+++ b/src/queries/get-pending-accounts.ts
@@ -47,7 +47,8 @@ const getPendingAccounts = (
     is_approved,
     created_by(first_name, last_name),
     account_id,
-    operation_type
+    operation_type,
+    is_delete_account
   `,
       {
         count: 'exact',

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -79,7 +79,7 @@ export type Database = {
           id: string
           initial_contract_value: number | null
           initial_head_count: number | null
-          is_active: boolean | null
+          is_active: boolean
           mode_of_payment_id: string | null
           name_of_signatory: string | null
           nature_of_business: string | null
@@ -117,7 +117,7 @@ export type Database = {
           id?: string
           initial_contract_value?: number | null
           initial_head_count?: number | null
-          is_active?: boolean | null
+          is_active?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null
           nature_of_business?: string | null
@@ -155,7 +155,7 @@ export type Database = {
           id?: string
           initial_contract_value?: number | null
           initial_head_count?: number | null
-          is_active?: boolean | null
+          is_active?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null
           nature_of_business?: string | null
@@ -556,6 +556,7 @@ export type Database = {
           initial_head_count: number | null
           is_active: boolean
           is_approved: boolean
+          is_delete_account: boolean
           mode_of_payment_id: string | null
           name_of_signatory: string | null
           nature_of_business: string | null
@@ -598,6 +599,7 @@ export type Database = {
           initial_head_count?: number | null
           is_active?: boolean
           is_approved?: boolean
+          is_delete_account?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null
           nature_of_business?: string | null
@@ -640,6 +642,7 @@ export type Database = {
           initial_head_count?: number | null
           is_active?: boolean
           is_approved?: boolean
+          is_delete_account?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null
           nature_of_business?: string | null

--- a/supabase/migrations/20241103003332_add_is_delete_account_column_to_pending_accounts.sql
+++ b/supabase/migrations/20241103003332_add_is_delete_account_column_to_pending_accounts.sql
@@ -1,0 +1,17 @@
+alter table "public"."accounts" alter column "is_active" set not null;
+
+alter table "public"."pending_accounts" add column "is_delete_account" boolean not null default false;
+
+create policy "Enable update for admin"
+on "public"."accounts"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added approval workflow for company deletion and improved user feedback for edit requests.

### What changed?
- Company deletion now requires admin approval instead of immediate deletion
- Added success toast notifications for edit request submissions
- Implemented check for existing pending requests before submitting new ones
- Added `is_delete_account` flag to pending_accounts table
- Modified account activation logic based on deletion status
- Enhanced error handling and user feedback during the approval process

### How to test?
1. Navigate to a company profile
2. Attempt to delete the company
3. Verify the deletion request is sent for approval
4. Check admin approval panel for the pending deletion request
5. Approve/reject the request and verify the company status updates accordingly
6. Try submitting multiple requests and verify the duplicate request handling
7. Verify toast notifications appear after submission

### Why make this change?
To implement a more controlled process for company deletions by requiring administrative approval, preventing accidental deletions, and maintaining better audit trails of account changes. This also improves user experience by providing clear feedback on request status.