### PR TITLE
feat(billing): implement pending billing statement approval workflow

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -731,6 +731,103 @@ export type Database = {
           },
         ]
       }
+      pending_billing_statements: {
+        Row: {
+          account_id: string
+          amount: number | null
+          amount_billed: number | null
+          amount_paid: number | null
+          balance: number | null
+          billing_period: number | null
+          commission_earned: number | null
+          commission_rate: number | null
+          created_at: string
+          created_by: string
+          due_date: string | null
+          id: string
+          is_active: boolean
+          is_approved: boolean
+          is_delete_billing_statement: boolean
+          mode_of_payment_id: string | null
+          operation_type: Database['public']['Enums']['pending_operation']
+          or_date: string | null
+          or_number: string | null
+          sa_number: string | null
+          total_contract_value: number | null
+          updated_at: string
+        }
+        Insert: {
+          account_id: string
+          amount?: number | null
+          amount_billed?: number | null
+          amount_paid?: number | null
+          balance?: number | null
+          billing_period?: number | null
+          commission_earned?: number | null
+          commission_rate?: number | null
+          created_at?: string
+          created_by: string
+          due_date?: string | null
+          id?: string
+          is_active?: boolean
+          is_approved?: boolean
+          is_delete_billing_statement?: boolean
+          mode_of_payment_id?: string | null
+          operation_type: Database['public']['Enums']['pending_operation']
+          or_date?: string | null
+          or_number?: string | null
+          sa_number?: string | null
+          total_contract_value?: number | null
+          updated_at?: string
+        }
+        Update: {
+          account_id?: string
+          amount?: number | null
+          amount_billed?: number | null
+          amount_paid?: number | null
+          balance?: number | null
+          billing_period?: number | null
+          commission_earned?: number | null
+          commission_rate?: number | null
+          created_at?: string
+          created_by?: string
+          due_date?: string | null
+          id?: string
+          is_active?: boolean
+          is_approved?: boolean
+          is_delete_billing_statement?: boolean
+          mode_of_payment_id?: string | null
+          operation_type?: Database['public']['Enums']['pending_operation']
+          or_date?: string | null
+          or_number?: string | null
+          sa_number?: string | null
+          total_contract_value?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'pending_billing_statements_account_id_fkey'
+            columns: ['account_id']
+            isOneToOne: false
+            referencedRelation: 'accounts'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_billing_statements_created_by_fkey'
+            columns: ['created_by']
+            isOneToOne: false
+            referencedRelation: 'user_profiles'
+            referencedColumns: ['user_id']
+          },
+          {
+            foreignKeyName: 'pending_billing_statements_mode_of_payment_id_fkey'
+            columns: ['mode_of_payment_id']
+            isOneToOne: false
+            referencedRelation: 'mode_of_payments'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       plan_types: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20241103014212_add_pending_billing_statements_table.sql
+++ b/supabase/migrations/20241103014212_add_pending_billing_statements_table.sql
@@ -1,0 +1,115 @@
+create table "public"."pending_billing_statements" (
+    "id" uuid not null default uuid_generate_v4(),
+    "due_date" date,
+    "or_number" text,
+    "or_date" date,
+    "sa_number" text,
+    "amount" double precision,
+    "total_contract_value" double precision,
+    "balance" double precision,
+    "billing_period" integer,
+    "is_active" boolean not null default true,
+    "amount_billed" double precision,
+    "amount_paid" double precision,
+    "commission_rate" double precision,
+    "commission_earned" double precision,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now(),
+    "account_id" uuid not null,
+    "mode_of_payment_id" uuid,
+    "created_by" uuid not null,
+    "is_approved" boolean not null default false,
+    "operation_type" pending_operation not null,
+    "is_delete_billing_statement" boolean not null default false
+);
+
+
+alter table "public"."pending_billing_statements" enable row level security;
+
+CREATE UNIQUE INDEX pending_billing_statements_pkey ON public.pending_billing_statements USING btree (id);
+
+alter table "public"."pending_billing_statements" add constraint "pending_billing_statements_pkey" PRIMARY KEY using index "pending_billing_statements_pkey";
+
+alter table "public"."pending_billing_statements" add constraint "billing_statements_billing_period_check" CHECK (((billing_period >= 1) AND (billing_period <= 31))) not valid;
+
+alter table "public"."pending_billing_statements" validate constraint "billing_statements_billing_period_check";
+
+alter table "public"."pending_billing_statements" add constraint "pending_billing_statements_account_id_fkey" FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_billing_statements" validate constraint "pending_billing_statements_account_id_fkey";
+
+alter table "public"."pending_billing_statements" add constraint "pending_billing_statements_created_by_fkey" FOREIGN KEY (created_by) REFERENCES user_profiles(user_id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_billing_statements" validate constraint "pending_billing_statements_created_by_fkey";
+
+alter table "public"."pending_billing_statements" add constraint "pending_billing_statements_mode_of_payment_id_fkey" FOREIGN KEY (mode_of_payment_id) REFERENCES mode_of_payments(id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_billing_statements" validate constraint "pending_billing_statements_mode_of_payment_id_fkey";
+
+grant delete on table "public"."pending_billing_statements" to "anon";
+
+grant insert on table "public"."pending_billing_statements" to "anon";
+
+grant references on table "public"."pending_billing_statements" to "anon";
+
+grant select on table "public"."pending_billing_statements" to "anon";
+
+grant trigger on table "public"."pending_billing_statements" to "anon";
+
+grant truncate on table "public"."pending_billing_statements" to "anon";
+
+grant update on table "public"."pending_billing_statements" to "anon";
+
+grant delete on table "public"."pending_billing_statements" to "authenticated";
+
+grant insert on table "public"."pending_billing_statements" to "authenticated";
+
+grant references on table "public"."pending_billing_statements" to "authenticated";
+
+grant select on table "public"."pending_billing_statements" to "authenticated";
+
+grant trigger on table "public"."pending_billing_statements" to "authenticated";
+
+grant truncate on table "public"."pending_billing_statements" to "authenticated";
+
+grant update on table "public"."pending_billing_statements" to "authenticated";
+
+grant delete on table "public"."pending_billing_statements" to "service_role";
+
+grant insert on table "public"."pending_billing_statements" to "service_role";
+
+grant references on table "public"."pending_billing_statements" to "service_role";
+
+grant select on table "public"."pending_billing_statements" to "service_role";
+
+grant trigger on table "public"."pending_billing_statements" to "service_role";
+
+grant truncate on table "public"."pending_billing_statements" to "service_role";
+
+grant update on table "public"."pending_billing_statements" to "service_role";
+
+create policy "Enable insert for users based on created_by"
+on "public"."pending_billing_statements"
+as permissive
+for insert
+to authenticated
+with check (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['finance'::text])))))))));
+
+
+create policy "Enable read for users based on created_by"
+on "public"."pending_billing_statements"
+as permissive
+for select
+to authenticated
+using (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['finance'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added approval workflow for billing statements by creating a pending statements table and updating the creation/update flow.

### What changed?
- Created new `pending_billing_statements` table to handle approval workflow
- Modified billing statement modal to insert into pending table instead of direct creation
- Updated success messages to reflect pending approval status
- Added operation type tracking to distinguish between insert and update requests
- Implemented row-level security policies for the pending table
- Added user tracking for pending statement requests

### How to test?
1. Create a new billing statement
2. Verify the success message indicates pending approval
3. Update an existing billing statement
4. Confirm the update message indicates pending approval
5. Check that only finance department users can access their pending statements
6. Verify that pending statements require approval before becoming active

### Why make this change?
To implement a proper approval workflow for billing statements, ensuring that all new entries and modifications go through a review process before being finalized in the system. This adds an important control layer for financial data integrity.