### PR TITLE
TIM-553 Fix dates on billing statements

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/billing-statements-columns.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/billing-statements-columns.tsx
@@ -7,6 +7,13 @@ import {
   formatPercentage,
 } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
 
+const normalizeToUTC = (date: Date): Date => {
+  const utcDate = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  )
+  return utcDate
+}
+
 const billingStatementsColumns: ColumnDef<Tables<'billing_statements'>>[] = [
   {
     accessorKey: 'account.company_name',
@@ -22,13 +29,10 @@ const billingStatementsColumns: ColumnDef<Tables<'billing_statements'>>[] = [
     accessorKey: 'due_date',
     header: ({ column }) => <TableHeader column={column} title="Due Date" />,
     cell: ({ row }) => {
-      return (
-        <div>
-          {row.original.due_date
-            ? format(row.getValue('due_date'), 'MMMM dd, yyyy')
-            : ''}
-        </div>
-      )
+      const dueDate = row.original.due_date
+        ? normalizeToUTC(new Date(row.original.due_date))
+        : null
+      return <div>{dueDate ? format(dueDate, 'MMMM dd, yyyy') : ''}</div>
     },
     accessorFn: (originalRow) =>
       originalRow.due_date ? format(originalRow.due_date, 'MMMM dd, yyyy') : '',
@@ -41,13 +45,10 @@ const billingStatementsColumns: ColumnDef<Tables<'billing_statements'>>[] = [
     accessorKey: 'or_date',
     header: ({ column }) => <TableHeader column={column} title="OR Date" />,
     cell: ({ row }) => {
-      return (
-        <div>
-          {row.original.or_date
-            ? format(row.getValue('or_date'), 'MMMM dd, yyyy')
-            : ''}
-        </div>
-      )
+      const orDate = row.original.or_date
+        ? normalizeToUTC(new Date(row.original.or_date))
+        : null
+      return <div>{orDate ? format(orDate, 'MMMM dd, yyyy') : ''}</div>
     },
     accessorFn: (originalRow) =>
       originalRow.or_date ? format(originalRow.or_date, 'MMMM dd, yyyy') : '',


### PR DESCRIPTION
### TL;DR
I'm so happy 

Fixed date handling in billing statements to ensure consistent UTC date representation.

### What changed?
- Added `normalizeToUTC` function to standardize date handling
- Updated date processing in billing statement columns and modal
- Modified date handling for `due_date` and `or_date` fields
- Ensured dates are properly normalized when submitting forms and displaying in tables

### How to test?
1. Create a new billing statement with due dates and OR dates
2. Edit existing billing statements and verify dates remain consistent
3. Verify date displays correctly in the billing statements table
4. Check that dates are not affected by different timezone settings

### Why make this change?
Dates were being inconsistently handled across the application, leading to potential timezone-related issues where dates could shift by a day depending on the user's timezone. This change ensures dates are consistently stored and displayed in UTC format, preventing any unintended date shifts. yes yes yes that's right