### PR TITLE
fix(pending-billing-statements): RLS for admin

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
@@ -1,0 +1,114 @@
+import { useToast } from '@/components/ui/use-toast'
+import { createBrowserClient } from '@/utils/supabase'
+import {
+  useUpdateMutation,
+  useUpsertMutation,
+} from '@supabase-cache-helpers/postgrest-react-query'
+import { ReactNode, useEffect } from 'react'
+
+interface BillingStatementActionButtonProps {
+  action: 'approve' | 'reject'
+  children: ReactNode
+}
+
+const BillingStatementActionButton = ({
+  action,
+  children,
+}: BillingStatementActionButtonProps) => {
+  const supabase = createBrowserClient()
+  const { toast } = useToast()
+  const { selectedData, setIsModalOpen, setIsLoading } =
+    useBillingStatementContext()
+
+  const {
+    mutateAsync: upsertBillingStatement,
+    isPending: isUpsertingBillingStatement,
+  } = useUpsertMutation(
+    // @ts-expect-error
+    supabase.from('billing_statements'),
+    ['id'],
+    null,
+    {
+      onError: () => {
+        toast({
+          title: 'Error',
+          description: 'An error occurred while approving the request',
+        })
+      },
+    },
+  )
+
+  const {
+    mutateAsync: updatePendingBillingStatement,
+    isPending: isUpdatingPendingBillingStatement,
+  } = useUpdateMutation(
+    // @ts-expect-error
+    supabase.from('pending_billing_statements'),
+    ['id'],
+    null,
+    {
+      onError: () => {
+        toast({
+          title: 'Error',
+          description: 'An error occurred while approving the request',
+        })
+      },
+    },
+  )
+
+  const handleClick = async () => {
+    if (action === 'approve') {
+      await upsertBillingStatement([
+        {
+          ...(selectedData.id && { id: selectedData.id }),
+          due_date: selectedData.due_date,
+          or_number: selectedData.or_number,
+          or_date: selectedData.or_date,
+          sa_number: selectedData.sa_number,
+          amount: selectedData.amount,
+          total_contract_value: selectedData.total_contract_value,
+          balance: selectedData.balance,
+          billing_period: selectedData.billing_period,
+          is_active: selectedData.is_active,
+          amount_billed: selectedData.amount_billed,
+          amount_paid: selectedData.amount_paid,
+          commission_rate: selectedData.commission_rate,
+          commission_earned: selectedData.commission_earned,
+          created_at: selectedData.created_at,
+          updated_at: selectedData.updated_at,
+          account_id: selectedData.account.id,
+          mode_of_payment_id: selectedData.mode_of_payment.id,
+        },
+      ]).catch((error) => {
+        toast({
+          title: 'Error',
+          description: error.message,
+        })
+      })
+    }
+
+    // Update pending billing statement
+    await updatePendingBillingStatement({
+      id: selectedData.id,
+      is_approved: action === 'approve',
+    })
+  }
+
+  useEffect(() => {
+    if (isUpsertingBillingStatement || isUpdatingPendingBillingStatement)
+      setIsLoading(true)
+    else setIsLoading(false)
+  }, [isUpsertingBillingStatement, isUpdatingPendingBillingStatement])
+
+  return <div onClick={handleClick}>{children}</div>
+}
+
+export default BillingStatementActionButton
+
+function useBillingStatementContext(): {
+  selectedData: any
+  setIsModalOpen: any
+  setIsLoading: any
+} {
+  throw new Error('Function not implemented.')
+}

--- a/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-info.tsx
@@ -1,8 +1,10 @@
 'use client'
 import { formatCurrency } from '@/app/(dashboard)/(home)/accounts/columns/accounts-columns'
+import BillingStatementActionButton from '@/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button'
 import { useBillingStatementsRequestContext } from '@/app/(dashboard)/admin/approval-request/billing-statements/billing-statements-request-provider'
 import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
 import OperationBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -11,9 +13,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { formatDate } from 'date-fns'
+import { Loader2 } from 'lucide-react'
 
 const BillingStatementInfo = () => {
-  const { selectedData, isModalOpen, setIsModalOpen } =
+  const { selectedData, isModalOpen, setIsModalOpen, isLoading } =
     useBillingStatementsRequestContext()
 
   return (
@@ -98,6 +101,20 @@ const BillingStatementInfo = () => {
             label="Commission Earned"
             value={formatCurrency(selectedData?.commission_earned)}
           />
+
+          {/* Actions */}
+          <div className="col-span-2 flex justify-end gap-x-2">
+            <BillingStatementActionButton action="reject">
+              <Button variant={'destructive'} disabled={isLoading}>
+                {isLoading ? <Loader2 className="animate-spin" /> : 'Reject'}
+              </Button>
+            </BillingStatementActionButton>
+            <BillingStatementActionButton action="approve">
+              <Button variant={'default'} disabled={isLoading}>
+                {isLoading ? <Loader2 className="animate-spin" /> : 'Approve'}
+              </Button>
+            </BillingStatementActionButton>
+          </div>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
### TL;DR
Added approval/rejection functionality for billing statements in the admin dashboard.

### What changed?
- Created a new `BillingStatementActionButton` component that handles the approval/rejection logic
- Added approve and reject buttons to the billing statement information modal
- Implemented loading states for the action buttons
- Added mutations to update billing statements and pending billing statements tables

### How to test?
1. Navigate to the admin dashboard's billing statement approval section
2. Open a billing statement's information modal
3. Click either the approve or reject button
4. Verify that the loading state is shown while processing
5. Confirm that success/error toasts appear appropriately
6. Check that the billing statement status updates correctly in both tables

### Why make this change?
To enable administrators to review and take action on pending billing statements directly from the information modal, streamlining the approval workflow process.