### PR TITLE
TIM-588 feat(billing-statements): add reject billing-statements approval

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
@@ -100,6 +100,7 @@ const BillingStatementActionButton = ({
     await updatePendingBillingStatement({
       id: selectedData.id,
       is_approved: action === 'approve',
+      is_active: action === 'approve',
     })
   }
 


### PR DESCRIPTION
### TL;DR
Added `is_active` flag to billing statement approval process

### What changed?
When approving a billing statement, the `is_active` flag is now set to true alongside the `is_approved` flag. When rejecting, both flags are set to false.

### How to test?
1. Navigate to the admin billing statement approval page
2. Select a pending billing statement
3. Approve the statement
4. Verify that both `is_approved` and `is_active` flags are set to true
5. Reject another statement
6. Verify both flags are set to false

### Why make this change?
To ensure billing statements are properly activated when approved and deactivated when rejected, maintaining consistency in the billing statement lifecycle management.