### PR TITLE
feat(billing): implement billing statement delete request workflow

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(billing statements)/billing-statements.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(billing statements)/billing-statements.tsx
@@ -63,7 +63,15 @@ const BillingStatements: FC<Props> = ({ companyId }) => {
                   data={{ ...billing } as BillingInfoProps['data']}
                 />
                 <div className="flex flex-row items-center justify-end lg:ml-auto lg:items-end">
-                  <DeleteBillingStatement setOpen={() => {}} id={billing.id} />
+                  <DeleteBillingStatement
+                    setOpen={() => {}}
+                    originalData={{
+                      ...billing,
+                      account_id: companyId,
+                      mode_of_payment_id: billing.mode_of_payments?.id ?? '',
+                      updated_at: billing.created_at,
+                    }}
+                  />
                 </div>
               </div>
             </CollapsibleContent>

--- a/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-action-button.tsx
@@ -69,7 +69,9 @@ const BillingStatementActionButton = ({
     if (action === 'approve') {
       await upsertBillingStatement([
         {
-          ...(selectedData.id && { id: selectedData.id }),
+          ...(selectedData.billing_statement_id && {
+            id: selectedData.billing_statement_id,
+          }),
           due_date: selectedData.due_date,
           or_number: selectedData.or_number,
           or_date: selectedData.or_date,
@@ -78,7 +80,7 @@ const BillingStatementActionButton = ({
           total_contract_value: selectedData.total_contract_value,
           balance: selectedData.balance,
           billing_period: selectedData.billing_period,
-          is_active: selectedData.is_active,
+          is_active: selectedData.is_delete_billing_statement ? false : true,
           amount_billed: selectedData.amount_billed,
           amount_paid: selectedData.amount_paid,
           commission_rate: selectedData.commission_rate,

--- a/src/app/(dashboard)/admin/approval-request/billing-statements/pending-billing-statements-column.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/pending-billing-statements-column.tsx
@@ -22,6 +22,10 @@ const pendingBillingStatementsColumns: ColumnDef<
     header: ({ column }) => <TableHeader column={column} title="Account" />,
   },
   {
+    accessorKey: 'or_number',
+    header: ({ column }) => <TableHeader column={column} title="OR Number" />,
+  },
+  {
     accessorKey: 'created_by',
     header: ({ column }) => (
       <TableHeader column={column} title="Requested By" />

--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -628,7 +628,13 @@ const BillingStatementModal = <TData,>({
             >
               {originalData && (
                 <DeleteBillingStatement
-                  id={originalData.id}
+                  originalData={{
+                    ...originalData,
+                    account_id: (originalData as any).account.id,
+                    mode_of_payment_id:
+                      (originalData as any).mode_of_payment?.id ?? '',
+                    updated_at: originalData.created_at,
+                  }}
                   setOpen={setOpen}
                 />
               )}

--- a/src/queries/ get-pending-billing-statements.ts
+++ b/src/queries/ get-pending-billing-statements.ts
@@ -29,7 +29,8 @@ const getPendingBillingStatements = (
       created_by(first_name, last_name),
       is_approved,
       operation_type,
-      is_delete_billing_statement
+      is_delete_billing_statement,
+      billing_statement_id
     `,
       {
         count: 'exact',

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -739,6 +739,7 @@ export type Database = {
           amount_paid: number | null
           balance: number | null
           billing_period: number | null
+          billing_statement_id: string | null
           commission_earned: number | null
           commission_rate: number | null
           created_at: string
@@ -763,6 +764,7 @@ export type Database = {
           amount_paid?: number | null
           balance?: number | null
           billing_period?: number | null
+          billing_statement_id?: string | null
           commission_earned?: number | null
           commission_rate?: number | null
           created_at?: string
@@ -787,6 +789,7 @@ export type Database = {
           amount_paid?: number | null
           balance?: number | null
           billing_period?: number | null
+          billing_statement_id?: string | null
           commission_earned?: number | null
           commission_rate?: number | null
           created_at?: string
@@ -810,6 +813,13 @@ export type Database = {
             columns: ['account_id']
             isOneToOne: false
             referencedRelation: 'accounts'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_billing_statements_billing_statement_id_fkey'
+            columns: ['billing_statement_id']
+            isOneToOne: false
+            referencedRelation: 'billing_statements'
             referencedColumns: ['id']
           },
           {


### PR DESCRIPTION
### TL;DR
Added support for deleting billing statements through the approval request workflow.

### What changed?
- Added `billing_statement_id` field to pending billing statements table
- Modified delete functionality to create a pending request instead of direct deletion
- Added OR Number column to pending billing statements table
- Updated billing statement action button to handle deletion requests
- Fixed ID reference in billing statement actions from `id` to `billing_statement_id`

### How to test?
1. Navigate to the billing statements section
2. Attempt to delete a billing statement
3. Verify the deletion request appears in the pending approval queue
4. Approve/reject the deletion request
5. Confirm the billing statement is properly deactivated upon approval

### Why make this change?
To ensure billing statement deletions go through the same approval workflow as other billing statement operations, maintaining consistency and audit trail in the system.