### PR TITLE
TIM-594 feat(billing-statements): add edit billing statements approval

### DIFF
--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -219,7 +219,7 @@ const BillingStatementModal = <TData,>({
           {
             ...data,
             // @ts-ignore
-            // id: originalData?.id ? originalData.id : undefined,
+            ...(originalData?.id && { billing_statement_id: originalData.id }),
             due_date: data.due_date
               ? normalizeToUTC(new Date(data.due_date))
               : undefined,


### PR DESCRIPTION
### TL;DR
Fixed billing statement ID handling during form submission

### What changed?
Modified the form submission logic to properly include the original billing statement ID when updating existing records. The ID is now conditionally spread into the submission data using the property name `billing_statement_id`.

### How to test?
1. Open an existing billing statement
2. Make modifications to any field
3. Save the changes
4. Verify that the update is successful and the existing record is modified rather than creating a new one

### Why make this change?
Previously, updates to existing billing statements weren't properly maintaining their ID reference, which could lead to duplicate records or failed updates. This change ensures the correct billing statement is updated by maintaining the ID relationship during form submission.