### PR TITLE
feat(billing): add pending billing statement request list

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/request/account-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/request/account-request-list-item.tsx
@@ -1,6 +1,5 @@
 import DeleteRequest from '@/app/(dashboard)/(home)/accounts/request/delete-request'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import OperationTypeBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
 import { Tables } from '@/types/database.types'
 import { formatDistanceToNow } from 'date-fns'
 import { FC } from 'react'
@@ -12,43 +11,9 @@ interface AccountRequestListItemProps {
 const AccountRequestListItem: FC<AccountRequestListItemProps> = ({
   pendingAccount,
 }) => {
-  const badgeIcon = () => {
-    switch (pendingAccount.operation_type) {
-      case 'insert':
-        return (
-          <Badge
-            variant="outline"
-            className="w-fit bg-green-100 text-green-500"
-          >
-            Add
-          </Badge>
-        )
-      case 'update':
-        return (
-          <Badge
-            variant="outline"
-            className="w-fit bg-yellow-100 text-yellow-500"
-          >
-            Edit
-          </Badge>
-        )
-      case 'delete':
-        return (
-          <Badge
-            variant="destructive"
-            className="w-fit bg-red-100 text-red-500"
-          >
-            Delete
-          </Badge>
-        )
-      default:
-        return null
-    }
-  }
-
   return (
     <div className="grid grid-cols-2 items-center gap-y-2 px-2 py-6">
-      {badgeIcon()}
+      <OperationTypeBadge operationType={pendingAccount.operation_type} />
       <span className="ml-auto w-fit text-sm text-muted-foreground">
         {formatDistanceToNow(new Date(pendingAccount.created_at), {
           addSuffix: true,

--- a/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
@@ -34,6 +34,7 @@ import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import DataTableRow from './data-table-row'
 import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
 import getBillingStatements from '@/queries/get-billing-statements'
+import BillingStatementRequest from '@/app/(dashboard)/(home)/billing-statements/request/billing-statement-request'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -84,6 +85,9 @@ const DataTable = <TData, TValue>({
           </div>
         </div>
       </PageHeader>
+      <div>
+        <BillingStatementRequest />
+      </div>
       <div className="flex h-full flex-col justify-between bg-card">
         <div className="h-full rounded-md border">
           <Table>

--- a/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list-item.tsx
@@ -1,0 +1,31 @@
+import { Tables } from '@/types/database.types'
+import OperationTypeBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
+import { formatDistanceToNow } from 'date-fns'
+
+interface PendingRequestListItemProps {
+  data: Tables<'pending_billing_statements'>
+  company_name: string
+}
+
+const PendingRequestListItem = ({
+  data,
+  company_name,
+}: PendingRequestListItemProps) => {
+  return (
+    <div className="grid grid-cols-2 items-center gap-y-2 px-2 py-6">
+      <OperationTypeBadge operationType={data.operation_type} />
+      <span className="ml-auto w-fit text-sm text-muted-foreground">
+        {formatDistanceToNow(new Date(data.created_at), {
+          addSuffix: true,
+        })}
+      </span>
+
+      <p className="text-sm font-medium">
+        {company_name} - {data.or_number}
+      </p>
+      {/* <DeleteRequest pendingAccountId={pendingAccount.id} /> */}
+    </div>
+  )
+}
+
+export default PendingRequestListItem

--- a/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list.tsx
@@ -1,0 +1,25 @@
+import BillingRequestListItem from '@/app/(dashboard)/(home)/billing-statements/request/billing-request-list-item'
+import getPendingBillingStatements from '@/queries/ get-pending-billing-statements'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const BillingRequestList = () => {
+  const supabase = createBrowserClient()
+
+  const { data: pendingBillings } = useQuery(
+    getPendingBillingStatements(supabase),
+  )
+  return (
+    <div className="grid grid-cols-1 divide-y">
+      {pendingBillings?.map((pendingBilling) => (
+        <BillingRequestListItem
+          key={pendingBilling.id}
+          data={pendingBilling as any}
+          company_name={pendingBilling.account.company_name}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default BillingRequestList

--- a/src/app/(dashboard)/(home)/billing-statements/request/billing-statement-request.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/request/billing-statement-request.tsx
@@ -1,0 +1,44 @@
+'use client'
+import BillingRequestList from '@/app/(dashboard)/(home)/billing-statements/request/billing-request-list'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import getPendingBillingStatements from '@/queries/ get-pending-billing-statements'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const BillingStatementRequest = () => {
+  const supabase = createBrowserClient()
+  const { count } = useQuery(getPendingBillingStatements(supabase))
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild={true}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="flex h-8 w-full rounded-none"
+        >
+          {count} Requests
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Submission Requests</DialogTitle>
+          <DialogDescription>
+            View and manage billing statement requests and submissions
+          </DialogDescription>
+        </DialogHeader>
+        <BillingRequestList />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default BillingStatementRequest


### PR DESCRIPTION
### TL;DR
Added a request management system for billing statements and refactored operation type badges into a reusable component.

### What changed?
- Created a new billing statement request management interface
- Added a dialog to display pending billing statement requests
- Implemented a request list component to show pending billing statements with their operation types
- Extracted operation type badge logic into a reusable component
- Added a counter to show the number of pending requests

### How to test?
1. Navigate to the billing statements page
2. Look for the "X Requests" button at the top of the table
3. Click the button to open the dialog
4. Verify that pending requests are displayed with:
   - Operation type badge (Add/Edit/Delete)
   - Company name and OR number
   - Time since creation
5. Verify that the request count updates correctly

### Why make this change?
To provide users with a centralized way to manage and track billing statement requests, making it easier to monitor pending changes and maintain data integrity. The reusable operation badge component also improves code maintainability and consistency across the application.