### PR TITLE
feat(billing): add delete request functionality for pending statements

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/request/billing-request-list-item.tsx
@@ -1,6 +1,7 @@
 import { Tables } from '@/types/database.types'
 import OperationTypeBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
 import { formatDistanceToNow } from 'date-fns'
+import DeleteBillingRequest from '@/app/(dashboard)/(home)/billing-statements/request/delete-billing-request'
 
 interface PendingRequestListItemProps {
   data: Tables<'pending_billing_statements'>
@@ -23,7 +24,7 @@ const PendingRequestListItem = ({
       <p className="text-sm font-medium">
         {company_name} - {data.or_number}
       </p>
-      {/* <DeleteRequest pendingAccountId={pendingAccount.id} /> */}
+      <DeleteBillingRequest pendingBillingId={data.id} />
     </div>
   )
 }

--- a/src/app/(dashboard)/(home)/billing-statements/request/delete-billing-request.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/request/delete-billing-request.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+import { createBrowserClient } from '@/utils/supabase'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { Loader2 } from 'lucide-react'
+import { useState } from 'react'
+
+interface DeleteBillingRequestProps {
+  pendingBillingId: string
+}
+
+const DeleteBillingRequest = ({
+  pendingBillingId,
+}: DeleteBillingRequestProps) => {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const { toast } = useToast()
+
+  const supabase = createBrowserClient()
+  const { mutate: updatePendingBilling, isPending } = useUpdateMutation(
+    // @ts-expect-error
+    supabase.from('pending_billing_statements'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Request deleted!',
+          description: 'Successfully deleted request',
+        })
+      },
+      onError: (err: any) => {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: err.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = () => {
+    updatePendingBilling({
+      id: pendingBillingId,
+      is_active: false,
+    })
+  }
+
+  return (
+    <>
+      {confirmDelete ? (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          disabled={isPending}
+          onClick={handleDelete}
+        >
+          {isPending ? <Loader2 className="animate-spin" /> : 'Are you sure?'}
+        </Button>
+      ) : (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          onClick={() => setConfirmDelete(true)}
+        >
+          Cancel
+        </Button>
+      )}
+    </>
+  )
+}
+
+export default DeleteBillingRequest

--- a/supabase/migrations/20241103064429_add_rls_for_update_on_pending_billing_statments.sql
+++ b/supabase/migrations/20241103064429_add_rls_for_update_on_pending_billing_statments.sql
@@ -1,0 +1,55 @@
+alter table "public"."pending_billing_statements" add column "billing_statement_id" uuid;
+
+alter table "public"."pending_billing_statements" add constraint "pending_billing_statements_billing_statement_id_fkey" FOREIGN KEY (billing_statement_id) REFERENCES billing_statements(id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_billing_statements" validate constraint "pending_billing_statements_billing_statement_id_fkey";
+
+create policy "Enable insert access for admin"
+on "public"."pending_billing_statements"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable read access for users based on created_by"
+on "public"."pending_billing_statements"
+as permissive
+for select
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update for admin"
+on "public"."pending_billing_statements"
+as permissive
+for update
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update for users based on created_by"
+on "public"."pending_billing_statements"
+as permissive
+for update
+to public
+using (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['finance'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added ability for users to delete pending billing statement requests and implemented corresponding RLS policies.

### What changed?
- Created a new `DeleteBillingRequest` component with confirmation dialog
- Added a delete button to the billing request list item
- Added a `billing_statement_id` column to pending_billing_statements table
- Implemented RLS policies for insert, read, and update operations on pending_billing_statements

### How to test?
1. Log in as a finance user
2. Navigate to billing statements
3. Locate a pending billing request
4. Click "Cancel" button
5. Confirm deletion in the confirmation dialog
6. Verify the request is removed from the list

### Why make this change?
To allow users to cancel their pending billing statement requests if they were submitted in error or are no longer needed, while ensuring proper access controls through RLS policies.