### PR TITLE
feat(billing): restrict billing statements RLS to admin only

### DIFF
--- a/supabase/migrations/20241103123506_remove_rls_access_to_employees_on_billing_statements_table.sql
+++ b/supabase/migrations/20241103123506_remove_rls_access_to_employees_on_billing_statements_table.sql
@@ -1,0 +1,29 @@
+drop policy "admin and finance department users to insert billing_statements" on "public"."billing_statements";
+
+drop policy "admin and finance department users to update billing_statements" on "public"."billing_statements";
+
+create policy "Enable insert access for admin"
+on "public"."billing_statements"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update access for admin"
+on "public"."billing_statements"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Restricted billing statements access to admin users only by removing finance department permissions.

### What changed?
- Removed existing RLS policies that allowed both admin and finance department users to insert and update billing statements
- Created new policies that exclusively grant insert and update permissions to admin department users
- Maintained the same policy structure but narrowed down the department check to 'admin' only

### How to test?
1. Log in as an admin user and verify you can still insert and update billing statements
2. Log in as a finance department user and confirm you can no longer insert or update billing statements
3. Attempt to create and modify billing statements with both user types to ensure proper access control

### Why make this change?
To enhance security by limiting billing statement modifications to admin users only, removing the previously granted access to finance department users. This ensures more controlled and restricted access to sensitive billing information.