### PR TITLE
feat(employees): add pending employee request workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "tailwind-merge": "^2.3.0",
     "undici": "^5.28.4",
     "usehooks-ts": "^3.1.0",
+    "uuid": "^11.0.2",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8",
     "zustand": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ dependencies:
   usehooks-ts:
     specifier: ^3.1.0
     version: 3.1.0(react@18.2.0)
+  uuid:
+    specifier: ^11.0.2
+    version: 11.0.2
   xlsx:
     specifier: ^0.18.5
     version: 0.18.5
@@ -12703,6 +12706,11 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: true
+
+  /uuid@11.0.2:
+    resolution: {integrity: sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==}
+    hasBin: true
+    dev: false
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -838,6 +838,80 @@ export type Database = {
           },
         ]
       }
+      pending_company_employees: {
+        Row: {
+          account_id: string | null
+          batch_id: string
+          birth_date: string | null
+          card_number: string | null
+          civil_status: string | null
+          created_at: string
+          created_by: string | null
+          effective_date: string | null
+          first_name: string | null
+          gender: string | null
+          id: string
+          is_active: boolean
+          is_approved: boolean
+          is_delete_employee: boolean
+          last_name: string | null
+          maximum_benefit_limit: string | null
+          operation_type: Database['public']['Enums']['pending_operation']
+          room_plan: string | null
+          updated_at: string
+        }
+        Insert: {
+          account_id?: string | null
+          batch_id: string
+          birth_date?: string | null
+          card_number?: string | null
+          civil_status?: string | null
+          created_at?: string
+          created_by?: string | null
+          effective_date?: string | null
+          first_name?: string | null
+          gender?: string | null
+          id?: string
+          is_active?: boolean
+          is_approved?: boolean
+          is_delete_employee?: boolean
+          last_name?: string | null
+          maximum_benefit_limit?: string | null
+          operation_type: Database['public']['Enums']['pending_operation']
+          room_plan?: string | null
+          updated_at?: string
+        }
+        Update: {
+          account_id?: string | null
+          batch_id?: string
+          birth_date?: string | null
+          card_number?: string | null
+          civil_status?: string | null
+          created_at?: string
+          created_by?: string | null
+          effective_date?: string | null
+          first_name?: string | null
+          gender?: string | null
+          id?: string
+          is_active?: boolean
+          is_approved?: boolean
+          is_delete_employee?: boolean
+          last_name?: string | null
+          maximum_benefit_limit?: string | null
+          operation_type?: Database['public']['Enums']['pending_operation']
+          room_plan?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'pending_company_employees_account_id_fkey'
+            columns: ['account_id']
+            isOneToOne: false
+            referencedRelation: 'accounts'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       plan_types: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20241103131928_add_pending_company_employees_table.sql
+++ b/supabase/migrations/20241103131928_add_pending_company_employees_table.sql
@@ -1,0 +1,104 @@
+create table "public"."pending_company_employees" (
+    "id" uuid not null default uuid_generate_v4(),
+    "is_active" boolean not null default true,
+    "account_id" uuid,
+    "first_name" character varying(255),
+    "last_name" character varying(255),
+    "birth_date" date,
+    "gender" character varying(255),
+    "civil_status" character varying(255),
+    "card_number" character varying(255),
+    "effective_date" date,
+    "room_plan" character varying(255),
+    "maximum_benefit_limit" character varying(255),
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now(),
+    "created_by" uuid,
+    "is_approved" boolean not null default false,
+    "is_delete_employee" boolean not null default false,
+    "operation_type" pending_operation not null,
+    "batch_id" uuid not null
+);
+
+
+alter table "public"."pending_company_employees" enable row level security;
+
+CREATE UNIQUE INDEX pending_company_employees_pkey ON public.pending_company_employees USING btree (id);
+
+alter table "public"."pending_company_employees" add constraint "pending_company_employees_pkey" PRIMARY KEY using index "pending_company_employees_pkey";
+
+alter table "public"."pending_company_employees" add constraint "pending_company_employees_account_id_fkey" FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE not valid;
+
+alter table "public"."pending_company_employees" validate constraint "pending_company_employees_account_id_fkey";
+
+alter table "public"."pending_company_employees" add constraint "pending_company_employees_created_by_fkey" FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL not valid;
+
+alter table "public"."pending_company_employees" validate constraint "pending_company_employees_created_by_fkey";
+
+grant delete on table "public"."pending_company_employees" to "anon";
+
+grant insert on table "public"."pending_company_employees" to "anon";
+
+grant references on table "public"."pending_company_employees" to "anon";
+
+grant select on table "public"."pending_company_employees" to "anon";
+
+grant trigger on table "public"."pending_company_employees" to "anon";
+
+grant truncate on table "public"."pending_company_employees" to "anon";
+
+grant update on table "public"."pending_company_employees" to "anon";
+
+grant delete on table "public"."pending_company_employees" to "authenticated";
+
+grant insert on table "public"."pending_company_employees" to "authenticated";
+
+grant references on table "public"."pending_company_employees" to "authenticated";
+
+grant select on table "public"."pending_company_employees" to "authenticated";
+
+grant trigger on table "public"."pending_company_employees" to "authenticated";
+
+grant truncate on table "public"."pending_company_employees" to "authenticated";
+
+grant update on table "public"."pending_company_employees" to "authenticated";
+
+grant delete on table "public"."pending_company_employees" to "service_role";
+
+grant insert on table "public"."pending_company_employees" to "service_role";
+
+grant references on table "public"."pending_company_employees" to "service_role";
+
+grant select on table "public"."pending_company_employees" to "service_role";
+
+grant trigger on table "public"."pending_company_employees" to "service_role";
+
+grant truncate on table "public"."pending_company_employees" to "service_role";
+
+grant update on table "public"."pending_company_employees" to "service_role";
+
+create policy "Enable insert for users based on created_by"
+on "public"."pending_company_employees"
+as permissive
+for insert
+to authenticated
+with check (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'marketing'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text])))))))));
+
+
+create policy "Enable read access for users based on created_by"
+on "public"."pending_company_employees"
+as permissive
+for select
+to authenticated
+using (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'marketing'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added pending employee management functionality with approval workflow

### What changed?
- Created new `pending_company_employees` table in the database
- Added UUID package for batch operation tracking
- Modified employee form to submit to pending table instead of direct updates
- Implemented operation tracking (insert/update) for employee changes
- Added row-level security policies for pending employee management

### How to test?
1. Create a new employee through the employee form
2. Verify the entry appears in the `pending_company_employees` table
3. Update an existing employee and confirm it creates a pending record
4. Verify that only authorized users (admin, marketing, finance, after-sales, under-writing) can access pending records
5. Confirm that users can only view their own pending submissions

### Why make this change?
To implement an approval workflow for employee management, ensuring changes to employee records are reviewed before being applied to the main system. This adds an additional layer of control and validation for employee data modifications.