### PR TITLE
feat(employees): implement pending employee approval details view

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/billing-statement-info.tsx
@@ -25,7 +25,7 @@ const BillingStatementInfo = () => {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-x-2">
             Billing Statement Approval Request
-            {/* <OperationBadge operationType={selectedData?.operation_type} /> */}
+            <OperationBadge operationType={selectedData?.operation_type} />
           </DialogTitle>
           <DialogDescription>
             Created by {(selectedData?.created_by as any)?.first_name}{' '}

--- a/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
@@ -1,6 +1,8 @@
 'use server'
 
 import PendingCompanyEmployeesTable from '@/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table'
+import PendingEmployeeInfo from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info'
+import { PendingEmployeeProvider } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 import getPendingCompanyEmployees from '@/queries/get-pending-company-employees'
 import { createServerClient } from '@/utils/supabase'
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
@@ -18,7 +20,10 @@ const CompanyEmployeesApprovalRequestPage = async () => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <PendingCompanyEmployeesTable />
+      <PendingEmployeeProvider>
+        <PendingCompanyEmployeesTable />
+        <PendingEmployeeInfo />
+      </PendingEmployeeProvider>
     </HydrationBoundary>
   )
 }

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table.tsx
@@ -7,6 +7,8 @@ import {
   PageHeader,
   PageTitle,
 } from '@/components/page-header'
+import TablePagination from '@/components/table-pagination'
+import TableSearch from '@/components/table-search'
 import {
   Table,
   TableBody,
@@ -59,6 +61,9 @@ const PendingCompanyEmployeesTable = () => {
             <PageTitle>Pending Company Employees</PageTitle>
             <PageDescription>{count} pending company employees</PageDescription>
           </div>
+          <div>
+            <TableSearch table={table} />
+          </div>
         </div>
       </PageHeader>
 
@@ -91,6 +96,7 @@ const PendingCompanyEmployeesTable = () => {
             </TableBody>
           </Table>
         </div>
+        <TablePagination table={table} />
       </div>
     </div>
   )

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info.tsx
@@ -1,0 +1,97 @@
+'use client'
+import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
+import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
+import OperationBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { formatDate } from 'date-fns'
+
+const PendingEmployeeInfo = () => {
+  const { selectedData, isModalOpen, setIsModalOpen } =
+    usePendingEmployeeContext()
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-x-2">
+            Pending Employee Approval Request
+            <OperationBadge operationType={selectedData?.operation_type} />
+          </DialogTitle>
+          <DialogDescription>
+            Created by {(selectedData as any)?.created_by?.first_name}{' '}
+            {(selectedData as any)?.created_by?.last_name} on{' '}
+            {selectedData?.created_at
+              ? formatDate(selectedData.created_at, 'PP')
+              : 'unknown date'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-y-2">
+          <ApprovalInformationItem
+            label="Last Name"
+            value={(selectedData as any)?.last_name}
+          />
+          <ApprovalInformationItem
+            label="First Name"
+            value={(selectedData as any)?.first_name}
+          />
+          <ApprovalInformationItem
+            label="Account"
+            value={(selectedData as any)?.account?.company_name}
+          />
+          <ApprovalInformationItem
+            label="Birth Date"
+            value={
+              (selectedData as any)?.birth_date
+                ? formatDate((selectedData as any).birth_date, 'PP')
+                : undefined
+            }
+          />
+          <ApprovalInformationItem
+            label="Gender"
+            value={(selectedData as any)?.gender}
+          />
+          <ApprovalInformationItem
+            label="Civil Status"
+            value={(selectedData as any)?.civil_status}
+          />
+          <ApprovalInformationItem
+            label="Card Number"
+            value={(selectedData as any)?.card_number}
+          />
+          <ApprovalInformationItem
+            label="Effective Date"
+            value={
+              (selectedData as any)?.effective_date
+                ? formatDate((selectedData as any).effective_date, 'PP')
+                : undefined
+            }
+          />
+          <ApprovalInformationItem
+            label="Room Plan"
+            value={(selectedData as any)?.room_plan}
+          />
+          <ApprovalInformationItem
+            label="Maximum Benefit Limit"
+            value={(selectedData as any)?.maximum_benefit_limit}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant={'destructive'}>Reject</Button>
+          <Button variant={'default'}>Approve</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default PendingEmployeeInfo

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { Tables } from '@/types/database.types'
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+const usePendingEmployeeContext = () => {
+  const context = useContext(PendingEmployeeContext)
+  if (!context) {
+    throw new Error(
+      'usePendingEmployeeContext must be used within a PendingEmployeeProvider',
+    )
+  }
+  return context
+}
+
+const PendingEmployeeContext = createContext({
+  isModalOpen: false,
+  setIsModalOpen: (_value: boolean) => {},
+  selectedData: undefined as Tables<'pending_company_employees'> | undefined,
+  setSelectedData: (_value: any) => {},
+  isLoading: false,
+  setIsLoading: (_value: boolean) => {},
+})
+
+const PendingEmployeeProvider = ({ children }: { children: ReactNode }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [selectedData, setSelectedData] = useState<any | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(false)
+
+  return (
+    <PendingEmployeeContext.Provider
+      value={{
+        isModalOpen,
+        setIsModalOpen,
+        selectedData,
+        setSelectedData,
+        isLoading,
+        setIsLoading,
+      }}
+    >
+      {children}
+    </PendingEmployeeContext.Provider>
+  )
+}
+
+export { PendingEmployeeProvider, usePendingEmployeeContext }

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-employees-row.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-employees-row.tsx
@@ -1,5 +1,6 @@
 import { Table, ColumnDef, flexRender } from '@tanstack/react-table'
 import { TableCell, TableRow } from '@/components/ui/table'
+import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 
 interface PendingEmployeesRowProps<TData> {
   table: Table<TData>
@@ -10,6 +11,13 @@ const PendingEmployeesRow = <TData,>({
   table,
   columns,
 }: PendingEmployeesRowProps<TData>) => {
+  const { setSelectedData, setIsModalOpen } = usePendingEmployeeContext()
+
+  const handleOnClick = (originalData: TData) => {
+    setSelectedData(originalData)
+    setIsModalOpen(true)
+  }
+
   return (
     <>
       {table.getRowModel().rows?.length ? (
@@ -17,7 +25,7 @@ const PendingEmployeesRow = <TData,>({
           <TableRow
             key={row.id}
             className="cursor-pointer hover:!bg-muted"
-            // onClick={() => handleOnClick(row.original)}
+            onClick={() => handleOnClick(row.original)}
           >
             {row.getVisibleCells().map((cell) => (
               <TableCell key={cell.id}>


### PR DESCRIPTION
### TL;DR
Added employee details modal and improved table functionality for pending company employees approval requests.

### What changed?
- Enabled the operation badge in billing statement info
- Added a new modal dialog to display detailed employee information
- Implemented context provider for managing employee selection state
- Added search and pagination functionality to the pending employees table
- Created click handler to view employee details when clicking table rows

### How to test?
1. Navigate to the pending company employees approval page
2. Verify search functionality works in the table
3. Test pagination controls
4. Click on any employee row to open the details modal
5. Confirm all employee information is displayed correctly
6. Verify approve/reject buttons are present
7. Check that the operation badge displays correctly

### Why make this change?
To provide administrators with a more detailed view of pending employee requests and better table management capabilities, making the approval process more efficient and user-friendly.