### PR TITLE
feat(employees): implement employee approval/reject workflow

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
@@ -1,0 +1,110 @@
+import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
+import { useToast } from '@/components/ui/use-toast'
+import { createBrowserClient } from '@/utils/supabase'
+import {
+  useUpdateMutation,
+  useUpsertMutation,
+} from '@supabase-cache-helpers/postgrest-react-query'
+import { FC, ReactNode, useEffect } from 'react'
+
+interface EmployeeActionButtonProps {
+  action: 'approve' | 'reject'
+  children: ReactNode
+}
+
+const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
+  action,
+  children,
+}) => {
+  const supabase = createBrowserClient()
+  const { toast } = useToast()
+  const { selectedData, setIsModalOpen, setIsLoading } =
+    usePendingEmployeeContext()
+
+  const { mutateAsync: upsertEmployee, isPending: isUpsertingEmployee } =
+    useUpsertMutation(
+      // @ts-ignore
+      supabase.from('company_employees'),
+      ['id'],
+      null,
+      {
+        onError: () => {
+          toast({
+            title: 'Error',
+            variant: 'destructive',
+            description: 'An error occurred while approving the request',
+          })
+        },
+      },
+    )
+
+  const {
+    mutateAsync: updatePendingEmployee,
+    isPending: isUpdatingPendingEmployee,
+  } = useUpdateMutation(
+    // @ts-ignore
+    supabase.from('pending_company_employees'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          title: 'Success',
+          description: 'The request has been approved successfully',
+        })
+        setIsModalOpen(false)
+      },
+      onError: () => {
+        toast({
+          title: 'Error',
+          variant: 'destructive',
+          description: 'An error occurred while approving the request',
+        })
+      },
+    },
+  )
+
+  const handleClick = async () => {
+    if (!selectedData) return
+    if (action === 'approve') {
+      await upsertEmployee([
+        {
+          // id: selectedData.id,
+          account_id: selectedData.account_id,
+          first_name: selectedData.first_name,
+          last_name: selectedData.last_name,
+          birth_date: selectedData.birth_date,
+          gender: selectedData.gender,
+          civil_status: selectedData.civil_status,
+          card_number: selectedData.card_number,
+          effective_date: selectedData.effective_date,
+          room_plan: selectedData.room_plan,
+          maximum_benefit_limit: selectedData.maximum_benefit_limit,
+          created_by: (selectedData.created_by as any)?.user_id,
+          is_active: selectedData.is_delete_employee ? false : true,
+        },
+      ]).catch((error) => {
+        toast({
+          title: 'Error',
+          description: error.message,
+        })
+      })
+    }
+
+    // Update pending employee
+    await updatePendingEmployee({
+      id: selectedData.id,
+      is_approved: action === 'approve',
+      is_active: action === 'approve',
+    })
+  }
+
+  useEffect(() => {
+    if (isUpsertingEmployee || isUpdatingPendingEmployee) setIsLoading(true)
+    else setIsLoading(false)
+  }, [isUpsertingEmployee, isUpdatingPendingEmployee])
+
+  return <div onClick={handleClick}>{children}</div>
+}
+
+export default EmployeeActionButton

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-columns.tsx
@@ -22,12 +22,12 @@ const pendingCompanyEmployeesColumns: ColumnDef<
     header: ({ column }) => <TableHeader column={column} title="Company" />,
   },
   {
-    accessorKey: 'first_name',
-    header: ({ column }) => <TableHeader column={column} title="Employee" />,
-  },
-  {
     accessorKey: 'last_name',
     header: ({ column }) => <TableHeader column={column} title="Last Name" />,
+  },
+  {
+    accessorKey: 'first_name',
+    header: ({ column }) => <TableHeader column={column} title="First" />,
   },
   {
     accessorKey: 'created_by',

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info.tsx
@@ -1,4 +1,5 @@
 'use client'
+import EmployeeActionButton from '@/app/(dashboard)/admin/approval-request/company-employees/employee-action-button'
 import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
 import OperationBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
@@ -12,9 +13,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { formatDate } from 'date-fns'
+import { Loader2 } from 'lucide-react'
 
 const PendingEmployeeInfo = () => {
-  const { selectedData, isModalOpen, setIsModalOpen } =
+  const { selectedData, isModalOpen, setIsModalOpen, isLoading } =
     usePendingEmployeeContext()
 
   return (
@@ -86,8 +88,16 @@ const PendingEmployeeInfo = () => {
         </div>
 
         <DialogFooter>
-          <Button variant={'destructive'}>Reject</Button>
-          <Button variant={'default'}>Approve</Button>
+          <EmployeeActionButton action="reject">
+            <Button variant={'destructive'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Reject'}
+            </Button>
+          </EmployeeActionButton>
+          <EmployeeActionButton action="approve">
+            <Button variant={'default'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Approve'}
+            </Button>
+          </EmployeeActionButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/queries/get-pending-company-employees.ts
+++ b/src/queries/get-pending-company-employees.ts
@@ -23,7 +23,7 @@ const getPendingCompanyEmployees = (
       maximum_benefit_limit,
       created_at,
       updated_at,
-      created_by(first_name, last_name),
+      created_by(first_name, last_name, user_id),
       is_approved,
       is_delete_employee,
       operation_type,


### PR DESCRIPTION
### TL;DR
Added approval/rejection functionality for pending company employee requests.

### What changed?
- Created new `EmployeeActionButton` component to handle approve/reject actions
- Updated pending employee info modal to include action buttons with loading states
- Reordered employee name columns to show last name before first name
- Added user_id to created_by query for proper employee creation tracking

### How to test?
1. Navigate to the admin approval request page
2. Select a pending company employee request
3. Click either "Approve" or "Reject" in the modal
4. Verify that:
   - Loading state is shown during action
   - Success/error toast appears after action
   - Modal closes on successful action
   - Employee data is properly created/updated in database

### Why make this change?
To implement the core functionality for administrators to process pending company employee requests, enabling them to either approve new employees or modifications to existing employee records.