### PR TITLE
feat(employees): add pending employee request list and view

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
@@ -1,6 +1,9 @@
+'use client'
+
 import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal'
 import EmployeesTableSearch from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-table-search'
 import ExportEmployees from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-employees'
+import EmployeeRequest from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request'
 import TablePagination from '@/components/table-pagination'
 import { Button } from '@/components/ui/button'
 import {
@@ -13,7 +16,6 @@ import {
 } from '@/components/ui/table'
 import {
   ColumnDef,
-  ColumnFiltersState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -72,6 +74,7 @@ const EmployeesDataTable = <TData, TValue>({
           <ExportEmployees />
         </div>
       </div>
+      <EmployeeRequest />
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list-item.tsx
@@ -1,0 +1,30 @@
+import { Tables } from '@/types/database.types'
+import { FC } from 'react'
+import OperationTypeBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
+import { formatDistanceToNow } from 'date-fns'
+
+interface EmployeeRequestListItemProps {
+  data: Tables<'pending_company_employees'>
+}
+
+const EmployeeRequestListItem: FC<EmployeeRequestListItemProps> = ({
+  data,
+}) => {
+  return (
+    <div className="grid grid-cols-2 items-center gap-y-2 px-2 py-6">
+      <OperationTypeBadge operationType={data.operation_type} />
+      <span className="ml-auto w-fit text-sm text-muted-foreground">
+        {formatDistanceToNow(new Date(data.created_at), {
+          addSuffix: true,
+        })}
+      </span>
+
+      <p className="text-sm font-medium">
+        {data.first_name} {data.last_name}
+      </p>
+      {/* <DeleteEmployeeRequest pendingEmployeeId={data.id} /> */}
+    </div>
+  )
+}
+
+export default EmployeeRequestListItem

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list.tsx
@@ -1,0 +1,27 @@
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import EmployeeRequestListItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list-item'
+import getPendingCompanyEmployees from '@/queries/get-pending-company-employees'
+import getPendingEmployeeByCompanyId from '@/queries/get-pending-employee-by-company-id'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const EmployeeRequestList = () => {
+  const { accountId } = useCompanyContext()
+  const supabase = createBrowserClient()
+
+  const { data: pendingEmployees } = useQuery(
+    getPendingEmployeeByCompanyId(supabase, accountId),
+  )
+  return (
+    <div className="grid grid-cols-1 divide-y">
+      {pendingEmployees?.map((pendingEmployee) => (
+        <EmployeeRequestListItem
+          key={pendingEmployee.id}
+          data={pendingEmployee as any}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default EmployeeRequestList

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import EmployeeRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import getPendingEmployeeByCompanyId from '@/queries/get-pending-employee-by-company-id'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const EmployeeRequest = () => {
+  const { accountId } = useCompanyContext()
+  const supabase = createBrowserClient()
+  const { count } = useQuery(getPendingEmployeeByCompanyId(supabase, accountId))
+  return (
+    <Dialog>
+      <DialogTrigger asChild={true}>
+        <Button
+          variant={'outline'}
+          size={'sm'}
+          className="flex h-8 w-full rounded-none"
+        >
+          {/* TODO: add count */}
+          {count} Requests
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Submission Requests</DialogTitle>
+          <DialogDescription>
+            View and manage employee requests and submissions
+          </DialogDescription>
+        </DialogHeader>
+        <EmployeeRequestList />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default EmployeeRequest

--- a/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/components/ui/table'
 import {
   ColumnDef,
-  ColumnFiltersState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -26,15 +25,14 @@ import {
 } from '@tanstack/react-table'
 import { useState } from 'react'
 
+import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
+import BillingStatementRequest from '@/app/(dashboard)/(home)/billing-statements/request/billing-statement-request'
 import TableSearch from '@/components/table-search'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useTableContext } from '@/providers/TableProvider'
+import getBillingStatements from '@/queries/get-billing-statements'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import DataTableRow from './data-table-row'
-import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
-import getBillingStatements from '@/queries/get-billing-statements'
-import BillingStatementRequest from '@/app/(dashboard)/(home)/billing-statements/request/billing-statement-request'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]

--- a/src/queries/get-pending-employee-by-company-id.ts
+++ b/src/queries/get-pending-employee-by-company-id.ts
@@ -1,0 +1,44 @@
+import { TypedSupabaseClient } from '@/types/typedSupabaseClient'
+
+const getPendingEmployeeByCompanyId = (
+  supabase: TypedSupabaseClient,
+  companyId: string,
+) => {
+  return supabase
+    .from('pending_company_employees')
+    .select(
+      `
+      id,
+      is_active,
+      account_id,
+      account:account_id(id, company_name),
+      first_name,
+      last_name,
+      birth_date,
+      gender,
+      civil_status,
+      card_number,
+      effective_date,
+      room_plan,
+      maximum_benefit_limit,
+      created_at,
+      updated_at,
+      created_by(first_name, last_name, user_id),
+      is_approved,
+      is_delete_employee,
+      operation_type,
+      batch_id,
+      company_employee_id
+    `,
+      {
+        count: 'exact',
+      },
+    )
+    .eq('is_approved', false)
+    .eq('is_active', true)
+    .eq('account_id', companyId)
+    .order('created_at', { ascending: false })
+    .throwOnError()
+}
+
+export default getPendingEmployeeByCompanyId


### PR DESCRIPTION
### TL;DR
Added a new employee request feature to display and manage pending employee submissions.

### What changed?
- Added a new employee request button that shows the count of pending requests
- Created a dialog component to display pending employee submissions
- Implemented list view for pending employee requests showing operation type and submission time
- Added query functionality to fetch pending employees by company ID

### How to test?
1. Navigate to the employees table view
2. Look for the "Requests" button showing the count of pending submissions
3. Click the button to open the dialog
4. Verify that pending employee submissions are displayed with their operation type and submission time
5. Confirm that the request count updates when new submissions are added or approved

### Why make this change?
To provide users with a streamlined way to view and manage pending employee submissions directly from the employees table view, improving visibility and workflow efficiency for handling employee requests.