### PR TITLE
feat(employees): add delete request functionality for pending employees

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form.tsx
@@ -1,5 +1,5 @@
-import employeeSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import employeeSchema from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -25,21 +25,17 @@ import {
 } from '@/components/ui/select'
 import { useToast } from '@/components/ui/use-toast'
 import { Tables } from '@/types/database.types'
+import normalizeToUTC from '@/utils/normalize-to-utc'
 import { createBrowserClient } from '@/utils/supabase'
 import { cn } from '@/utils/tailwind'
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  useInsertMutation,
-  useUpdateMutation,
-  useUpsertMutation,
-} from '@supabase-cache-helpers/postgrest-react-query'
+import { useInsertMutation } from '@supabase-cache-helpers/postgrest-react-query'
 import { format } from 'date-fns'
 import { CalendarIcon, Loader2 } from 'lucide-react'
 import { FC, FormEventHandler, useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import normalizeToUTC from '@/utils/normalize-to-utc'
 import { v4 as uuidv4 } from 'uuid'
+import { z } from 'zod'
 
 interface EmployeeFormProps {
   setIsOpen: (value: boolean) => void

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/delete-employee-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/delete-employee-request.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+import { Tables } from '@/types/database.types'
+import { createBrowserClient } from '@/utils/supabase'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { Loader2 } from 'lucide-react'
+import { useState } from 'react'
+
+interface DeleteEmployeeRequestProps {
+  data: Tables<'pending_company_employees'>
+}
+
+const DeleteEmployeeRequest = ({ data }: DeleteEmployeeRequestProps) => {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const { toast } = useToast()
+
+  const supabase = createBrowserClient()
+  const { mutate: updatePendingEmployee, isPending } = useUpdateMutation(
+    // @ts-ignore
+    supabase.from('pending_company_employees'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Request deleted!',
+          description: 'Successfully deleted request',
+        })
+      },
+      onError: (err: any) => {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: err.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = () => {
+    updatePendingEmployee({
+      id: data.id,
+      is_active: false,
+    })
+  }
+  return (
+    <>
+      {confirmDelete ? (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          disabled={isPending}
+          onClick={handleDelete}
+        >
+          {isPending ? <Loader2 className="animate-spin" /> : 'Are you sure?'}
+        </Button>
+      ) : (
+        <Button
+          size={'sm'}
+          variant={'link'}
+          className="ml-auto px-0 text-xs text-destructive"
+          onClick={() => setConfirmDelete(true)}
+        >
+          Cancel
+        </Button>
+      )}
+    </>
+  )
+}
+
+export default DeleteEmployeeRequest

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list-item.tsx
@@ -2,6 +2,7 @@ import { Tables } from '@/types/database.types'
 import { FC } from 'react'
 import OperationTypeBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
 import { formatDistanceToNow } from 'date-fns'
+import DeleteEmployeeRequest from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/delete-employee-request'
 
 interface EmployeeRequestListItemProps {
   data: Tables<'pending_company_employees'>
@@ -22,7 +23,7 @@ const EmployeeRequestListItem: FC<EmployeeRequestListItemProps> = ({
       <p className="text-sm font-medium">
         {data.first_name} {data.last_name}
       </p>
-      {/* <DeleteEmployeeRequest pendingEmployeeId={data.id} /> */}
+      <DeleteEmployeeRequest data={data} />
     </div>
   )
 }


### PR DESCRIPTION
### TL;DR
Added functionality to delete pending employee requests and reorganized employee form imports.

### What changed?
- Created a new `DeleteEmployeeRequest` component with confirmation dialog
- Added delete functionality to employee request list items
- Implemented toast notifications for successful/failed deletions
- Reorganized imports in the employee form for better code organization

### How to test?
1. Navigate to the employee requests section
2. Locate any pending employee request
3. Click the "Cancel" button
4. Confirm deletion in the confirmation dialog
5. Verify the toast notification appears
6. Confirm the request is removed from the list

### Why make this change?
To provide administrators the ability to remove pending employee requests that are no longer needed, improving user management capabilities and maintaining data cleanliness in the system.