### PR TITLE
feat(employees): restrict employee table RLS to admin

### DIFF
--- a/supabase/migrations/20241104034008_remove_rls_access_to_employee_table_for_employees.sql
+++ b/supabase/migrations/20241104034008_remove_rls_access_to_employee_table_for_employees.sql
@@ -1,0 +1,43 @@
+drop policy "all departments can insert company employees except agent" on "public"."company_employees";
+
+drop policy "all departments can update company employees except agent" on "public"."company_employees";
+
+drop policy "user can see company employees" on "public"."company_employees";
+
+create policy "Enable read access for users except agent"
+on "public"."company_employees"
+as permissive
+for select
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['marketing'::text, 'after-sales'::text, 'under-writing'::text, 'finance'::text, 'admin'::text]))))))));
+
+
+create policy "Enable update access for admin"
+on "public"."company_employees"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+create policy "Enable update for users based on created_by"
+on "public"."pending_company_employees"
+as permissive
+for update
+to public
+using (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'marketing'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Restricted employee table access by removing existing RLS policies and implementing more specific access controls.

### What changed?
- Removed three existing RLS policies for company employees table
- Added new RLS policy for read access that excludes agents
- Created admin-specific update policy for company employees
- Implemented policy for pending company employees that allows updates only by the creator when not approved

### How to test?
1. Login as an agent and verify they cannot access company employees
2. Login as admin and confirm they can update company employee records
3. Login as non-admin department user and verify they can only read company employee data
4. Test pending company employees updates:
   - Verify only creator can update their pending records
   - Confirm updates only work when record is not approved
   - Test with different department roles to ensure proper access

### Why make this change?
To enhance data security by implementing more granular access controls and ensuring that only authorized personnel can modify employee records while maintaining appropriate read access for other departments.