### PR TITLE
feat(employees): implement batch import grouping in approval list

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/import-employees.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/import-employees.tsx
@@ -47,6 +47,7 @@ const ImportEmployees = ({ isOpen, setIsOpen }: ImportEmployeesProps) => {
     } = await supabase.auth.getUser()
     if (!user) throw new Error('User not found')
 
+    const batchId = uuidv4()
     const employees = data.validData.map((employee) => ({
       account_id: accountId,
       first_name: employee.first_name,
@@ -60,7 +61,7 @@ const ImportEmployees = ({ isOpen, setIsOpen }: ImportEmployeesProps) => {
       maximum_benefit_limit: employee.maximum_benefit_limit,
       created_by: user.id,
       operation_type: 'insert',
-      batch_id: uuidv4(),
+      batch_id: batchId,
     }))
 
     await mutateAsync(employees)

--- a/src/app/(dashboard)/admin/approval-request/company-employees/groupData.ts
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/groupData.ts
@@ -1,0 +1,37 @@
+const groupData = (data: any) => {
+  const groupedData: any[] = []
+  const batchIdMap: { [key: string]: any[] } = {}
+
+  data.forEach((item: any) => {
+    if (item.batch_id) {
+      if (!batchIdMap[item.batch_id]) {
+        batchIdMap[item.batch_id] = []
+      }
+      batchIdMap[item.batch_id].push(item)
+    } else {
+      groupedData.push(item)
+    }
+  })
+
+  for (const batchId in batchIdMap) {
+    if (batchIdMap[batchId].length > 1) {
+      const firstItem = batchIdMap[batchId][0]
+      groupedData.push({
+        batch_id: batchId,
+        items: batchIdMap[batchId],
+        created_by: firstItem.created_by,
+        account: firstItem.account,
+        created_at: firstItem.created_at,
+        operation_type: firstItem.operation_type,
+        first_name: '-',
+        last_name: '-',
+      })
+    } else {
+      groupedData.push(batchIdMap[batchId][0])
+    }
+  }
+
+  return groupedData
+}
+
+export default groupData

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-columns.tsx
@@ -1,5 +1,6 @@
 import OperationBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
 import TableHeader from '@/components/table-header'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
@@ -14,7 +15,15 @@ const pendingCompanyEmployeesColumns: ColumnDef<
     header: ({ column }) => <TableHeader column={column} title="Action" />,
     accessorFn: (row) => row.operation_type,
     cell: ({ row }) => (
-      <OperationBadge operationType={row.original.operation_type} />
+      <div className="flex items-center gap-1">
+        <OperationBadge operationType={row.original.operation_type} />
+        {(row.original as any).items &&
+          (row.original as any).items.length > 1 && (
+            <Badge variant="outline" className="w-fit bg-blue-400 text-blue-50">
+              Batch
+            </Badge>
+          )}
+      </div>
     ),
   },
   {
@@ -23,11 +32,25 @@ const pendingCompanyEmployeesColumns: ColumnDef<
   },
   {
     accessorKey: 'last_name',
-    header: ({ column }) => <TableHeader column={column} title="Last Name" />,
+    header: ({ column }) => <TableHeader column={column} title="Surname" />,
+    cell: ({ row }) => {
+      if (!row.original.last_name) {
+        return (row.original as any)?.items
+          ? (row.original as any)?.items.length
+          : 0
+      }
+      return <div>{row.original.last_name}</div>
+    },
   },
   {
     accessorKey: 'first_name',
-    header: ({ column }) => <TableHeader column={column} title="First" />,
+    header: ({ column }) => <TableHeader column={column} title="First Name" />,
+    cell: ({ row }) => {
+      if (!row.original.first_name) {
+        return <div>-</div>
+      }
+      return <div>{row.original.first_name}</div>
+    },
   },
   {
     accessorKey: 'created_by',

--- a/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import groupData from '@/app/(dashboard)/admin/approval-request/company-employees/groupData'
 import pendingCompanyEmployeesColumns from '@/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-columns'
 import PendingEmployeesRow from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employees-row'
 import {
@@ -28,17 +29,19 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table'
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 
 const PendingCompanyEmployeesTable = () => {
   const supabase = createBrowserClient()
   const { count, data } = useQuery(getPendingCompanyEmployees(supabase, 'desc'))
 
+  const memoizedData = useMemo(() => groupData(data as any), [data])
+
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState<any>('')
 
   const table = useReactTable({
-    data: (data as any) || [],
+    data: memoizedData,
     columns: pendingCompanyEmployeesColumns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),


### PR DESCRIPTION
### TL;DR
Added batch processing functionality for employee imports and enhanced the pending employees approval table UI.

### What changed?
- Implemented batch grouping for imported employees using a shared batch ID
- Added a "Batch" badge indicator for grouped employee records
- Updated the pending employees table to display the number of employees in a batch
- Modified column headers and display logic for first name and surname fields
- Introduced a new `groupData` utility function to organize employee records by batch

### How to test?
1. Import multiple employees at once through the employee import feature
2. Navigate to the admin approval request page
3. Verify that batch imports are grouped together with a "Batch" badge
4. Confirm that the number of employees in each batch is displayed correctly
5. Check that single employee records display normally with their first and last names

### Why make this change?
To improve the user experience when handling bulk employee imports by grouping related records together, making it easier for administrators to review and approve multiple employee additions in a single action.