### PR TITLE
feat(employees): add batch employee approval request view

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
@@ -1,0 +1,66 @@
+import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
+import { formatDate } from 'date-fns'
+import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
+
+const BatchEmployee = () => {
+  const { selectedData } = usePendingEmployeeContext()
+  console.log(selectedData)
+  return (
+    <div className="max-h-[500px] divide-y-2 overflow-y-auto">
+      {(selectedData as any)?.items.map((item: any) => (
+        <div className="py grid grid-cols-2 gap-y-2" key={item.id}>
+          <ApprovalInformationItem
+            label="Last Name"
+            value={(item as any)?.last_name}
+          />
+          <ApprovalInformationItem
+            label="First Name"
+            value={(item as any)?.first_name}
+          />
+          <ApprovalInformationItem
+            label="Account"
+            value={(item as any)?.account?.company_name}
+          />
+          <ApprovalInformationItem
+            label="Birth Date"
+            value={
+              (selectedData as any)?.birth_date
+                ? formatDate((item as any).birth_date, 'PP')
+                : undefined
+            }
+          />
+          <ApprovalInformationItem
+            label="Gender"
+            value={(item as any)?.gender}
+          />
+          <ApprovalInformationItem
+            label="Civil Status"
+            value={(item as any)?.civil_status}
+          />
+          <ApprovalInformationItem
+            label="Card Number"
+            value={(item as any)?.card_number}
+          />
+          <ApprovalInformationItem
+            label="Effective Date"
+            value={
+              (item as any)?.effective_date
+                ? formatDate((item as any).effective_date, 'PP')
+                : undefined
+            }
+          />
+          <ApprovalInformationItem
+            label="Room Plan"
+            value={(item as any)?.room_plan}
+          />
+          <ApprovalInformationItem
+            label="Maximum Benefit Limit"
+            value={(item as any)?.maximum_benefit_limit}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default BatchEmployee

--- a/src/app/(dashboard)/admin/approval-request/company-employees/information/employee-information.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/information/employee-information.tsx
@@ -1,0 +1,61 @@
+import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
+import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
+import { formatDate } from 'date-fns'
+
+const EmployeeInformation = () => {
+  const { selectedData } = usePendingEmployeeContext()
+  return (
+    <div className="grid grid-cols-2 gap-y-2">
+      <ApprovalInformationItem
+        label="Last Name"
+        value={(selectedData as any)?.last_name}
+      />
+      <ApprovalInformationItem
+        label="First Name"
+        value={(selectedData as any)?.first_name}
+      />
+      <ApprovalInformationItem
+        label="Account"
+        value={(selectedData as any)?.account?.company_name}
+      />
+      <ApprovalInformationItem
+        label="Birth Date"
+        value={
+          (selectedData as any)?.birth_date
+            ? formatDate((selectedData as any).birth_date, 'PP')
+            : undefined
+        }
+      />
+      <ApprovalInformationItem
+        label="Gender"
+        value={(selectedData as any)?.gender}
+      />
+      <ApprovalInformationItem
+        label="Civil Status"
+        value={(selectedData as any)?.civil_status}
+      />
+      <ApprovalInformationItem
+        label="Card Number"
+        value={(selectedData as any)?.card_number}
+      />
+      <ApprovalInformationItem
+        label="Effective Date"
+        value={
+          (selectedData as any)?.effective_date
+            ? formatDate((selectedData as any).effective_date, 'PP')
+            : undefined
+        }
+      />
+      <ApprovalInformationItem
+        label="Room Plan"
+        value={(selectedData as any)?.room_plan}
+      />
+      <ApprovalInformationItem
+        label="Maximum Benefit Limit"
+        value={(selectedData as any)?.maximum_benefit_limit}
+      />
+    </div>
+  )
+}
+
+export default EmployeeInformation

--- a/src/app/(dashboard)/admin/approval-request/company-employees/information/pending-employee-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/information/pending-employee-info.tsx
@@ -1,8 +1,11 @@
 'use client'
 import EmployeeActionButton from '@/app/(dashboard)/admin/approval-request/company-employees/employee-action-button'
+import BatchEmployee from '@/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee'
+import EmployeeInformation from '@/app/(dashboard)/admin/approval-request/company-employees/information/employee-information'
 import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/components/approval-information-item'
 import OperationBadge from '@/app/(dashboard)/admin/approval-request/components/operation-badge'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -25,7 +28,22 @@ const PendingEmployeeInfo = () => {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-x-2">
             Pending Employee Approval Request
-            <OperationBadge operationType={selectedData?.operation_type} />
+            <div className="flex items-center gap-x-1">
+              <OperationBadge operationType={selectedData?.operation_type} />
+              {(selectedData as any)?.items && (
+                <>
+                  <Badge
+                    variant="outline"
+                    className="w-fit bg-blue-400 text-blue-50"
+                  >
+                    Batch
+                  </Badge>
+                  <Badge variant={'outline'}>
+                    {(selectedData as any)?.items.length} Employees
+                  </Badge>
+                </>
+              )}
+            </div>
           </DialogTitle>
           <DialogDescription>
             Created by {(selectedData as any)?.created_by?.first_name}{' '}
@@ -36,56 +54,11 @@ const PendingEmployeeInfo = () => {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid grid-cols-2 gap-y-2">
-          <ApprovalInformationItem
-            label="Last Name"
-            value={(selectedData as any)?.last_name}
-          />
-          <ApprovalInformationItem
-            label="First Name"
-            value={(selectedData as any)?.first_name}
-          />
-          <ApprovalInformationItem
-            label="Account"
-            value={(selectedData as any)?.account?.company_name}
-          />
-          <ApprovalInformationItem
-            label="Birth Date"
-            value={
-              (selectedData as any)?.birth_date
-                ? formatDate((selectedData as any).birth_date, 'PP')
-                : undefined
-            }
-          />
-          <ApprovalInformationItem
-            label="Gender"
-            value={(selectedData as any)?.gender}
-          />
-          <ApprovalInformationItem
-            label="Civil Status"
-            value={(selectedData as any)?.civil_status}
-          />
-          <ApprovalInformationItem
-            label="Card Number"
-            value={(selectedData as any)?.card_number}
-          />
-          <ApprovalInformationItem
-            label="Effective Date"
-            value={
-              (selectedData as any)?.effective_date
-                ? formatDate((selectedData as any).effective_date, 'PP')
-                : undefined
-            }
-          />
-          <ApprovalInformationItem
-            label="Room Plan"
-            value={(selectedData as any)?.room_plan}
-          />
-          <ApprovalInformationItem
-            label="Maximum Benefit Limit"
-            value={(selectedData as any)?.maximum_benefit_limit}
-          />
-        </div>
+        {(selectedData as any)?.items ? (
+          <BatchEmployee />
+        ) : (
+          <EmployeeInformation />
+        )}
 
         <DialogFooter>
           <EmployeeActionButton action="reject">

--- a/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
@@ -1,7 +1,7 @@
 'use server'
 
+import PendingEmployeeInfo from '@/app/(dashboard)/admin/approval-request/company-employees/information/pending-employee-info'
 import PendingCompanyEmployeesTable from '@/app/(dashboard)/admin/approval-request/company-employees/pending-company-employees-table'
-import PendingEmployeeInfo from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-info'
 import { PendingEmployeeProvider } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 import getPendingCompanyEmployees from '@/queries/get-pending-company-employees'
 import { createServerClient } from '@/utils/supabase'


### PR DESCRIPTION
### TL;DR
Added support for batch employee approval requests in the admin dashboard

### What changed?
- Created new components to handle batch employee information display
- Split employee information display into separate components for single and batch views
- Added badges to indicate batch requests and employee count
- Implemented scrollable view for batch employee data
- Reorganized file structure for better component organization

### How to test?
1. Navigate to the admin approval request dashboard
2. Select a batch employee request from the pending list
3. Verify that multiple employees are displayed with a scrollable interface
4. Confirm that batch indicators and employee count are visible
5. Test both single and batch employee request views
6. Verify all employee information fields are displayed correctly

### Why make this change?
To support the approval workflow for batch employee submissions, allowing administrators to review and approve multiple employee requests simultaneously while maintaining a clean and organized interface.