### PR TITLE
feat(employees): implement batch employee approval handling

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
@@ -1,10 +1,8 @@
 import { usePendingEmployeeContext } from '@/app/(dashboard)/admin/approval-request/company-employees/pending-employee-provider'
 import { useToast } from '@/components/ui/use-toast'
+import { Tables } from '@/types/database.types'
 import { createBrowserClient } from '@/utils/supabase'
-import {
-  useUpdateMutation,
-  useUpsertMutation,
-} from '@supabase-cache-helpers/postgrest-react-query'
+import { useUpsertMutation } from '@supabase-cache-helpers/postgrest-react-query'
 import { FC, ReactNode, useEffect } from 'react'
 
 interface EmployeeActionButtonProps {
@@ -41,7 +39,7 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
   const {
     mutateAsync: updatePendingEmployee,
     isPending: isUpdatingPendingEmployee,
-  } = useUpdateMutation(
+  } = useUpsertMutation(
     // @ts-ignore
     supabase.from('pending_company_employees'),
     ['id'],
@@ -67,12 +65,85 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
   const handleClick = async () => {
     if (!selectedData) return
     if (action === 'approve') {
-      await upsertEmployee([
-        {
-          ...(selectedData.company_employee_id && {
-            id: selectedData.company_employee_id,
+      await upsertEmployee(
+        (selectedData as any)?.items
+          ? (selectedData as any)?.items.map((item: any) => ({
+              account_id: item.account_id,
+              first_name: item.first_name,
+              last_name: item.last_name,
+              birth_date: item.birth_date,
+              gender: item.gender,
+              civil_status: item.civil_status,
+              card_number: item.card_number,
+              effective_date: item.effective_date,
+              room_plan: item.room_plan,
+              maximum_benefit_limit: item.maximum_benefit_limit,
+              created_by: (item.created_by as any)?.user_id,
+            }))
+          : [
+              {
+                ...(selectedData.company_employee_id && {
+                  id: selectedData.company_employee_id,
+                }),
+                account_id: selectedData.account_id,
+                first_name: selectedData.first_name,
+                last_name: selectedData.last_name,
+                birth_date: selectedData.birth_date,
+                gender: selectedData.gender,
+                civil_status: selectedData.civil_status,
+                card_number: selectedData.card_number,
+                effective_date: selectedData.effective_date,
+                room_plan: selectedData.room_plan,
+                maximum_benefit_limit: selectedData.maximum_benefit_limit,
+                created_by: (selectedData.created_by as any)?.user_id,
+                is_active: selectedData.is_delete_employee ? false : true,
+              },
+            ],
+      ).catch((error) => {
+        toast({
+          title: 'Error',
+          description: error.message,
+        })
+      })
+    }
+
+    // Update pending employee
+    if ((selectedData as any)?.items) {
+      await updatePendingEmployee(
+        (selectedData as any).items.map(
+          (item: Tables<'pending_company_employees'>) => ({
+            id: item.id,
+            is_approved: action === 'approve',
+            is_active: action === 'approve',
+            created_by: (item.created_by as any)?.user_id,
+            operation_type: item.operation_type,
+            batch_id: item.batch_id,
+            first_name: item.first_name,
+            last_name: item.last_name,
+            birth_date: item.birth_date,
+            gender: item.gender,
+            civil_status: item.civil_status,
+            card_number: item.card_number,
+            effective_date: item.effective_date,
+            room_plan: item.room_plan,
+            maximum_benefit_limit: item.maximum_benefit_limit,
           }),
-          account_id: selectedData.account_id,
+        ),
+      ).catch((error) => {
+        toast({
+          title: 'Error',
+          description: error.message,
+        })
+      })
+    } else {
+      await updatePendingEmployee([
+        {
+          id: selectedData.id,
+          is_approved: action === 'approve',
+          is_active: action === 'approve',
+          created_by: (selectedData.created_by as any)?.user_id,
+          operation_type: selectedData.operation_type,
+          batch_id: selectedData.batch_id,
           first_name: selectedData.first_name,
           last_name: selectedData.last_name,
           birth_date: selectedData.birth_date,
@@ -82,8 +153,6 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
           effective_date: selectedData.effective_date,
           room_plan: selectedData.room_plan,
           maximum_benefit_limit: selectedData.maximum_benefit_limit,
-          created_by: (selectedData.created_by as any)?.user_id,
-          is_active: selectedData.is_delete_employee ? false : true,
         },
       ]).catch((error) => {
         toast({
@@ -92,19 +161,12 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
         })
       })
     }
-
-    // Update pending employee
-    await updatePendingEmployee({
-      id: selectedData.id,
-      is_approved: action === 'approve',
-      is_active: action === 'approve',
-    })
   }
 
   useEffect(() => {
     if (isUpsertingEmployee || isUpdatingPendingEmployee) setIsLoading(true)
     else setIsLoading(false)
-  }, [isUpsertingEmployee, isUpdatingPendingEmployee])
+  }, [isUpsertingEmployee, isUpdatingPendingEmployee, setIsLoading])
 
   return <div onClick={handleClick}>{children}</div>
 }

--- a/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
@@ -4,7 +4,6 @@ import ApprovalInformationItem from '@/app/(dashboard)/admin/approval-request/co
 
 const BatchEmployee = () => {
   const { selectedData } = usePendingEmployeeContext()
-  console.log(selectedData)
   return (
     <div className="max-h-[500px] divide-y-2 overflow-y-auto">
       {(selectedData as any)?.items.map((item: any) => (


### PR DESCRIPTION
### TL;DR
Enhanced employee approval functionality to support both single and batch employee operations.

### What changed?
- Modified the employee action button to handle both individual and batch employee approvals
- Updated the upsert mutation logic to process multiple employees simultaneously
- Added comprehensive error handling for both employee creation and status updates
- Removed console.log statement from batch employee component
- Included additional employee data fields in the upsert operation

### How to test?
1. Navigate to the admin approval request section
2. Test single employee approval:
   - Select an individual employee
   - Click approve/reject button
   - Verify employee status updates correctly
2. Test batch employee approval:
   - Select a batch of employees
   - Click approve/reject button
   - Verify all employees in batch are processed
3. Verify error messages appear when operations fail

### Why make this change?
To support bulk employee processing while maintaining existing single employee functionality, improving efficiency for administrators handling multiple employee approvals simultaneously.