### PR TITLE
TIM-622 Submission for backend

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/data-table.tsx
@@ -152,7 +152,7 @@ const DataTable = <TData extends IData, TValue>({
             <div className="flex flex-row gap-4">
               <TableSearch table={table} />
               <AddAccountButton />
-              <ExportAccountsModal />
+              <ExportAccountsModal exportData={'accounts'} />
             </div>
           </div>
         </PageHeader>

--- a/supabase/migrations/20241104150917_add_policy_for_users_on_export_table.sql
+++ b/supabase/migrations/20241104150917_add_policy_for_users_on_export_table.sql
@@ -1,0 +1,56 @@
+drop policy "Enable read access for users except agent" on "public"."company_employees";
+
+drop policy "Enable update access for admin" on "public"."company_employees";
+
+drop policy "Enable update for users based on created_by" on "public"."pending_company_employees";
+
+create policy "all departments can insert company employees except agent"
+on "public"."company_employees"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['marketing'::text, 'after-sales'::text, 'under-writing'::text, 'finance'::text, 'admin'::text]))))))));
+
+
+create policy "all departments can update company employees except agent"
+on "public"."company_employees"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['marketing'::text, 'after-sales'::text, 'under-writing'::text, 'finance'::text, 'admin'::text]))))))))
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['marketing'::text, 'after-sales'::text, 'under-writing'::text, 'finance'::text, 'admin'::text]))))))));
+
+
+create policy "user can see company employees"
+on "public"."company_employees"
+as permissive
+for select
+to authenticated
+using (true);
+
+
+create policy "Enable users to insert on table"
+on "public"."pending_export_requests"
+as permissive
+for insert
+to authenticated
+with check (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'marketing'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
YAYYYYY
Added functionality to submit export requests for accounts data through a modal interface.

### What changed?
- Added export type parameter to `ExportAccountsModal` component
- Implemented Supabase integration for submitting export requests
- Added success and error toast notifications
- Included loading state handling for the confirm button
- Connected the export request to the authenticated user

### How to test?
1. Navigate to the accounts page
2. Click the export button to open the modal
3. Click confirm to submit an export request
4. Verify that a success toast appears
5. Verify the request appears in the `pending_export_requests` table
6. Test error handling by disconnecting from the database and attempting an export

### Why make this change?
To provide users with a secure way to request data exports while maintaining control over data access through an approval process. This ensures sensitive data is handled appropriately and maintains an audit trail of export requests.