### PR TITLE
feat(accounts): add loading state component

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/loading.tsx
+++ b/src/app/(dashboard)/(home)/accounts/loading.tsx
@@ -1,0 +1,19 @@
+import { PageHeader, PageTitle } from '@/components/page-header'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const AccountLoading = () => {
+  return (
+    <div className="flex flex-col">
+      <PageHeader>
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:justify-start">
+          <div>
+            <PageTitle>Accounts</PageTitle>
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+      </PageHeader>
+    </div>
+  )
+}
+
+export default AccountLoading


### PR DESCRIPTION
### TL;DR
Added a loading state component for the Accounts page

### What changed?
Created a new loading component that displays a skeleton UI while the Accounts page data is being fetched. The component includes a page header with the "Accounts" title and a skeleton loader for additional content.

### How to test?
1. Navigate to the Accounts page
2. Verify that the loading state appears momentarily before the full content loads
3. Ensure the skeleton UI matches the layout of the actual content
4. Test with slow network conditions to better observe the loading state

### Why make this change?
To improve user experience by providing visual feedback during data loading, preventing a blank screen and reducing perceived loading times. This follows best practices for progressive loading and maintains visual consistency with the rest of the application.