### PR TITLE
feat(admin): add loading state for account approval page

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/accounts/loading.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/loading.tsx
@@ -1,0 +1,19 @@
+import { PageHeader, PageTitle } from '@/components/page-header'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const AccountApprovalLoading = () => {
+  return (
+    <div className="flex flex-col">
+      <PageHeader>
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:justify-start">
+          <div>
+            <PageTitle>Pending Accounts</PageTitle>
+            <Skeleton className="h-4 w-20" />
+          </div>
+        </div>
+      </PageHeader>
+    </div>
+  )
+}
+
+export default AccountApprovalLoading


### PR DESCRIPTION
### TL;DR
Added a loading state component for the account approval page in the admin dashboard.

### What changed?
Created a new loading component that displays a skeleton UI while the account approval page loads. The component includes a page header with a "Pending Accounts" title and a skeleton placeholder for additional content.

### How to test?
1. Navigate to the admin dashboard's account approval page
2. Verify that the loading state appears momentarily before the main content loads
3. Confirm the skeleton UI matches the layout of the actual content

### Why make this change?
To improve user experience by providing visual feedback during data loading, preventing a blank screen and reducing perceived loading times. This follows best practices for progressive loading states in React applications.