### PR TITLE
feat(types): implement dynamic type editing component

### DIFF
--- a/src/app/(dashboard)/admin/types/edit/edit-type-fields.tsx
+++ b/src/app/(dashboard)/admin/types/edit/edit-type-fields.tsx
@@ -1,0 +1,67 @@
+import typeSchema from '@/app/(dashboard)/admin/types/type-schema'
+import { Button } from '@/components/ui/button'
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Loader2 } from 'lucide-react'
+import { FC, FormEventHandler } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
+
+interface Props {
+  handleEdit: FormEventHandler<HTMLFormElement>
+  isPending: boolean
+  name: string
+}
+
+const EditTypeFields: FC<Props> = ({ handleEdit, isPending, name }) => {
+  const form = useFormContext<z.infer<typeof typeSchema>>()
+
+  return (
+    <form onSubmit={handleEdit}>
+      <DialogHeader>
+        <DialogTitle className="break-all pt-2 text-left">
+          Edit {name} type
+        </DialogTitle>
+        <DialogDescription className="text-left">
+          Edit the type name
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-4 py-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem className="grid grid-cols-4 items-center gap-4">
+              <FormLabel className="text-right">Name</FormLabel>
+              <FormControl>
+                <Input {...field} disabled={isPending} className="col-span-3" />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </div>
+      <DialogFooter>
+        <Button disabled={isPending}>
+          {isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            'Save changes'
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}
+
+export default EditTypeFields

--- a/src/app/(dashboard)/admin/types/edit/edit-type.tsx
+++ b/src/app/(dashboard)/admin/types/edit/edit-type.tsx
@@ -1,32 +1,21 @@
 import { TypeTabs } from '@/app/(dashboard)/admin/types/type-card'
 import typeSchema from '@/app/(dashboard)/admin/types/type-schema'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
+import { Form } from '@/components/ui/form'
 import { useToast } from '@/components/ui/use-toast'
 import { createBrowserClient } from '@/utils/supabase'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
-import { Loader2, Pencil } from 'lucide-react'
-import { FC, FormEvent, FormEventHandler, useCallback } from 'react'
+import { Pencil } from 'lucide-react'
+import dynamic from 'next/dynamic'
+import { FC, FormEventHandler, Suspense, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+
+const EditTypeFields = dynamic(() => import('./edit-type-fields'), {
+  ssr: false,
+})
 
 interface EditTypeProps {
   id: string
@@ -82,43 +71,13 @@ const EditType: FC<EditTypeProps> = ({ id, name, page }) => {
           </Button>
         </DialogTrigger>
         <DialogContent>
-          <form onSubmit={handleEdit}>
-            <DialogHeader>
-              <DialogTitle className="break-all pt-2 text-left">
-                Edit {name} type
-              </DialogTitle>
-              <DialogDescription className="text-left">
-                Edit the type name
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid gap-4 py-4">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem className="grid grid-cols-4 items-center gap-4">
-                    <FormLabel className="text-right">Name</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        disabled={isPending}
-                        className="col-span-3"
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-            </div>
-            <DialogFooter>
-              <Button disabled={isPending}>
-                {isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  'Save changes'
-                )}
-              </Button>
-            </DialogFooter>
-          </form>
+          <Suspense fallback={<div>Loading...</div>}>
+            <EditTypeFields
+              handleEdit={handleEdit}
+              isPending={isPending}
+              name={name}
+            />
+          </Suspense>
         </DialogContent>
       </Form>
     </Dialog>

--- a/src/app/(dashboard)/admin/types/loading.tsx
+++ b/src/app/(dashboard)/admin/types/loading.tsx
@@ -1,0 +1,13 @@
+const TypesLoading = () => {
+  return (
+    <div className="flex w-full flex-row">
+      <div className="absolute -left-[600px] z-20 h-[calc(100vh-64px)] w-full border-r border-border bg-white transition-all duration-1000 sm:-left-96 sm:w-96 md:-left-24 md:-z-10 lg:relative lg:left-0 lg:z-20">
+        <div className="flex flex-row items-center justify-start px-8 py-9">
+          <h2 className="text-3xl font-extrabold">Manage Types</h2>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TypesLoading

--- a/src/app/(dashboard)/admin/types/type-list.tsx
+++ b/src/app/(dashboard)/admin/types/type-list.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import { FC } from 'react'
 import DeleteType from './delete-type'
 import { TypeTabs } from './type-card'
-import EditType from '@/app/(dashboard)/admin/types/edit-type'
+import EditType from '@/app/(dashboard)/admin/types/edit/edit-type'
 import { format } from 'date-fns'
 
 const TypeListItem = ({


### PR DESCRIPTION
### TL;DR
Split the edit type form into a separate component and added dynamic loading capabilities.

### What changed?
- Created a new `EditTypeFields` component to handle the form fields and submission
- Implemented dynamic loading using `next/dynamic` for the edit form
- Added a loading state component for the types page
- Moved edit-related components to a dedicated `/edit` directory

### How to test?
1. Navigate to the admin types page
2. Click the edit button on any type
3. Verify the edit form loads dynamically
4. Confirm the loading state appears while the form is being loaded
5. Test that editing a type name still functions correctly

### Why make this change?
This change improves the application's performance by implementing code splitting and lazy loading for the edit form component. The separation of concerns also makes the code more maintainable and easier to update in the future.