### PR TITLE
feat(admin): add loading state for activity logs

### DIFF
--- a/src/app/(dashboard)/admin/logs/loading.tsx
+++ b/src/app/(dashboard)/admin/logs/loading.tsx
@@ -1,0 +1,13 @@
+const LogsLoading = () => {
+  return (
+    <div className="flex w-full flex-row">
+      <div className="absolute -left-[600px] z-20 h-[calc(100vh-64px)] w-full border-r border-border bg-white transition-all duration-1000 sm:-left-96 sm:w-96 md:-left-24 md:-z-10 lg:relative lg:left-0 lg:z-20">
+        <div className="flex flex-row items-center justify-start px-8 py-9">
+          <h2 className="text-3xl font-extrabold">Activity Logs</h2>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LogsLoading


### PR DESCRIPTION
### TL;DR
Added a loading state component for the Activity Logs admin page.

### What changed?
Created a new loading component that displays a placeholder layout while the Activity Logs page data is being fetched. The component includes a responsive sidebar with the "Activity Logs" heading.

### How to test?
1. Navigate to the admin/logs page
2. Verify that the loading state appears briefly before the main content loads
3. Test responsiveness by viewing on different screen sizes (mobile, tablet, desktop)
4. Confirm the transition animations work smoothly

### Why make this change?
To improve user experience by providing visual feedback during data loading, preventing layout shifts, and maintaining a consistent UI structure throughout the loading process.