### PR TITLE
feat(dashboard): add loading state component

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/loading.tsx
@@ -1,0 +1,14 @@
+import PageTitle from '@/app/(dashboard)/(home)/(dashboard)/page-title'
+
+const HomeLoading = () => {
+  return (
+    <div className="p-6">
+      <PageTitle
+        title="Mock Dashboard"
+        description="Welcome to the dashboard"
+      />
+    </div>
+  )
+}
+
+export default HomeLoading


### PR DESCRIPTION
### TL;DR
Added a loading state component for the dashboard home page.

### What changed?
Created a new loading component that displays a page title with "Mock Dashboard" text while the main dashboard content is being loaded.

### How to test?
1. Navigate to the dashboard home page
2. Verify that the loading state appears momentarily before the main content loads
3. Confirm the loading state shows "Mock Dashboard" title and "Welcome to the dashboard" description

### Why make this change?
To improve user experience by providing visual feedback during the dashboard loading process, preventing a blank screen while content is being fetched or rendered.