### PR TITLE
feat(layout): replace Geist with Inter font

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,14 @@
-import { GeistSans } from 'geist/font/sans'
+import ReactQueryProvider from '@/providers/ReactQueryProvider'
 import ThemeProvider from '@/providers/ThemeProvider'
+import dynamic from 'next/dynamic'
+import { Inter } from 'next/font/google'
 import NextTopLoader from 'nextjs-toploader'
 import './globals.css'
-import ReactQueryProvider from '@/providers/ReactQueryProvider'
-import dynamic from 'next/dynamic'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-sans',
+})
 
 const Toaster = dynamic(
   () => import('@/components/ui/toaster').then((mod) => mod.Toaster),
@@ -38,11 +43,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html
-      lang="en"
-      className={GeistSans.className}
-      style={{ colorScheme: 'dark' }}
-    >
+    <html lang="en" className={inter.className} style={{ colorScheme: 'dark' }}>
       <body className="bg-background text-foreground">
         <NextTopLoader showSpinner={false} height={2} color="#2acf80" />
         <ThemeProvider


### PR DESCRIPTION
### TL;DR
Switched from Geist Sans to Inter font for the application's typography.

### What changed?
- Replaced Geist Sans with Inter font from Google Fonts
- Added Inter font configuration with Latin subset support
- Updated the font variable naming to `--font-sans`
- Reorganized imports for better code organization

### How to test?
1. Run the application locally
2. Verify that the Inter font is properly loaded and applied across all text elements
3. Ensure the font renders correctly across different browsers and devices
4. Confirm that the Latin character subset displays properly

### Why make this change?
Inter is a highly readable, open-source font designed specifically for computer screens. It provides better accessibility and consistent rendering across different platforms while being freely available through Google Fonts, reducing external dependencies and improving load times.