### PR TITLE
feat(accounts): add active status badge and column

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
+++ b/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
@@ -5,6 +5,8 @@ import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
 import { format } from 'date-fns'
 import normalizeToUTC from '@/utils/normalize-to-utc'
+import { Badge } from '@/components/ui/badge'
+import ActiveBadge from '@/components/active-badge'
 
 export const formatCurrency = (value: number | null | undefined) => {
   if (value === null || value === undefined) {
@@ -20,6 +22,13 @@ export const formatPercentage = (value: number | null | undefined) => {
   return `${value.toFixed(2)}%`
 }
 const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
+  {
+    accessorKey: 'is_account_active',
+    header: ({ column }) => <TableHeader column={column} title="Active" />,
+    cell: ({ row }) => (
+      <ActiveBadge isActive={row.original.is_account_active} />
+    ),
+  },
   {
     accessorKey: 'company_name',
     header: ({ column }) => (

--- a/src/components/active-badge.tsx
+++ b/src/components/active-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge'
+
+const ActiveBadge = ({ isActive }: { isActive: boolean }) => {
+  switch (isActive) {
+    case true:
+      return (
+        <Badge
+          variant={'outline'}
+          className="w-fit bg-green-100 text-green-500"
+        >
+          Active
+        </Badge>
+      )
+    case false:
+      return (
+        <Badge variant={'outline'} className="w-fit bg-red-100 text-red-500">
+          Inactive
+        </Badge>
+      )
+  }
+}
+
+export default ActiveBadge

--- a/src/queries/get-accounts.ts
+++ b/src/queries/get-accounts.ts
@@ -39,7 +39,9 @@ const getAccounts = (supabase: TypedSupabaseClient) => {
   updated_at,
   name_of_signatory,
   designation_of_contact_person,
-  email_address_of_contact_person
+  email_address_of_contact_person,
+  is_account_active
+
   `,
       {
         count: 'exact',

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -79,6 +79,7 @@ export type Database = {
           id: string
           initial_contract_value: number | null
           initial_head_count: number | null
+          is_account_active: boolean
           is_active: boolean
           mode_of_payment_id: string | null
           name_of_signatory: string | null
@@ -117,6 +118,7 @@ export type Database = {
           id?: string
           initial_contract_value?: number | null
           initial_head_count?: number | null
+          is_account_active?: boolean
           is_active?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null
@@ -155,6 +157,7 @@ export type Database = {
           id?: string
           initial_contract_value?: number | null
           initial_head_count?: number | null
+          is_account_active?: boolean
           is_active?: boolean
           mode_of_payment_id?: string | null
           name_of_signatory?: string | null

--- a/supabase/migrations/20241107024658_add_is_account_active_column_on_accounts.sql
+++ b/supabase/migrations/20241107024658_add_is_account_active_column_on_accounts.sql
@@ -1,0 +1,3 @@
+alter table "public"."accounts" add column "is_account_active" boolean not null default true;
+
+


### PR DESCRIPTION
### TL;DR
Added an account status indicator to display whether accounts are active or inactive.

### What changed?
- Added a new `is_account_active` boolean column to the accounts table
- Created a new `ActiveBadge` component that displays a colored badge indicating active/inactive status
- Added a new column to the accounts table UI that shows the active status using the badge
- Updated database types to include the new `is_account_active` field
- Modified the accounts query to fetch the new status field

### How to test?
1. Run the new migration to add the `is_account_active` column
2. Navigate to the accounts table
3. Verify that each account row displays either a green "Active" badge or a red "Inactive" badge
4. Update an account's active status in the database and confirm the badge updates accordingly

### Why make this change?
To provide clear visual feedback about an account's operational status, making it easier for users to quickly identify which accounts are currently active or inactive in the system.