### PR TITLE
TIM-664 Add requests on requests tab for employee exports

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
@@ -30,6 +30,7 @@ import { Plus } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
+import EmployeeExportRequests from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -78,7 +79,10 @@ const EmployeesDataTable = <TData, TValue>({
           <EmployeeExportModal exportData={'employees'} />
         </div>
       </div>
-      <EmployeeRequest />
+      <div className="flex flex-row">
+        <EmployeeRequest />
+        <EmployeeExportRequests />
+      </div>
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests-list-item.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const EmployeeExportRequestsListItem = () => {
+  return <div></div>
+}
+
+export default EmployeeExportRequestsListItem

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests.tsx
@@ -1,7 +1,4 @@
-'use client'
-import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
-import EmployeeRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list'
-import { Button } from '@/components/ui/button'
+import React from 'react'
 import {
   Dialog,
   DialogContent,
@@ -10,15 +7,19 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import getPendingEmployeeByCompanyId from '@/queries/get-pending-employee-by-company-id'
+import { Button } from '@/components/ui/button'
+import EmployeeRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getPendingEmployeeExports from '@/queries/get-pending-employee-exports'
 
-const EmployeeRequest = () => {
+const EmployeeExportRequests = () => {
   const { accountId } = useCompanyContext()
   const supabase = createBrowserClient()
-  const { count } = useQuery(getPendingEmployeeByCompanyId(supabase, accountId))
+  const { count } = useQuery(
+    getPendingEmployeeExports(supabase, accountId, 'employees'),
+  )
 
   return (
     <Dialog>
@@ -26,17 +27,17 @@ const EmployeeRequest = () => {
         <Button
           variant={'outline'}
           size={'sm'}
-          className="flex h-8 w-full rounded-none"
+          className="flex h-8 w-fit rounded-none"
         >
           {/* TODO: add count */}
-          {count} Employee Requests
+          {count} Export Requests
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Submission Requests</DialogTitle>
           <DialogDescription>
-            View and manage employee requests and submissions
+            View and manage export requests and submissions
           </DialogDescription>
         </DialogHeader>
         <EmployeeRequestList />
@@ -45,4 +46,4 @@ const EmployeeRequest = () => {
   )
 }
 
-export default EmployeeRequest
+export default EmployeeExportRequests

--- a/src/queries/get-pending-employee-exports.tsx
+++ b/src/queries/get-pending-employee-exports.tsx
@@ -1,0 +1,22 @@
+import { TypedSupabaseClient } from '@/types/typedSupabaseClient'
+import { Enums } from '@/types/database.types'
+
+const getPendingEmployeeExports = (
+  supabase: TypedSupabaseClient,
+  accountId: string,
+  exportType: Enums<'export_type'>,
+) => {
+  return supabase
+    .from('pending_export_requests')
+    .select(`id, export_type`, {
+      count: 'exact',
+      head: true,
+    })
+    .eq('is_approved', false)
+    .eq('is_active', true)
+    .eq('export_type', exportType)
+    .eq('account_id', accountId)
+    .throwOnError()
+}
+
+export default getPendingEmployeeExports


### PR DESCRIPTION
### TL;DR
YAYYYYY
Added an export requests button and counter to track pending employee export requests.

### What changed?
- Added a new `EmployeeExportRequests` component to display pending export requests
- Created a new query `getPendingEmployeeExports` to fetch pending export request counts
- Updated the employees data table to show both employee requests and export requests side by side
- Added a new list item component for export requests

### How to test?
1. Navigate to the employees data table
2. Verify that both "Employee Requests" and "Export Requests" buttons are visible
3. Confirm that the count on each button reflects the correct number of pending requests
4. Click on "Export Requests" to verify the modal opens and displays pending export requests

### Why make this change?
To provide users with visibility into pending export requests and improve the workflow for managing employee data exports. This addition helps users track and manage export requests more effectively alongside regular employee requests.