### PR TITLE
TIM-677 feat(home): add retention rate chart

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/page.tsx
@@ -4,6 +4,7 @@ import ClientAcquisitionCard from '@/app/(dashboard)/(home)/(dashboard)/client-a
 import PageTitle from './page-title'
 import PreviousStatement from './previous-statement'
 import { Metadata } from 'next'
+import RetentionRateCard from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card'
 
 export const metadata = async (): Promise<Metadata> => {
   return {
@@ -20,6 +21,7 @@ const Dashboard = () => {
       />
       <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-2">
         <ClientAcquisitionCard />
+        <RetentionRateCard />
         <PreviousStatement />
         <PreviousStatement />
       </div>

--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/chart-config.ts
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/chart-config.ts
@@ -1,0 +1,13 @@
+import { ChartConfig } from '@/components/ui/chart'
+
+const chartConfig = {
+  retentionRate: {
+    label: 'Retention Rate',
+  },
+  safari: {
+    label: 'Safari',
+    color: 'hsl(var(--chart-2))',
+  },
+} satisfies ChartConfig
+
+export default chartConfig

--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
@@ -1,0 +1,30 @@
+import RetentionRateChart from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-chart'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { format, subMonths } from 'date-fns'
+
+const RetentionRateCard = () => {
+  const last12Months = subMonths(new Date(), 12)
+
+  return (
+    <Card className="col-span-1">
+      <CardHeader>
+        <CardTitle className="text-base font-medium">Retention Rate</CardTitle>
+        <CardDescription className="text-xs font-medium">
+          From {format(last12Months, 'MMM yyyy')} to{' '}
+          {format(new Date(), 'MMM yyyy')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0">
+        <RetentionRateChart />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default RetentionRateCard

--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-chart.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import chartConfig from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/chart-config'
+import { ChartConfig, ChartContainer } from '@/components/ui/chart'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { subMonths, subYears } from 'date-fns'
+import { useMemo } from 'react'
+import {
+  Label,
+  PolarGrid,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart,
+} from 'recharts'
+
+const RetentionRateChart = () => {
+  const supabase = createBrowserClient()
+
+  const { data } = useQuery(
+    supabase
+      .from('accounts')
+      .select('is_account_active, created_at', {
+        count: 'exact',
+      })
+      .lte(
+        'created_at',
+        new Date().toLocaleString('en-US', { timeZone: 'UTC' }),
+      )
+      .throwOnError(),
+  )
+
+  const retentionRate = useMemo(() => {
+    if (!data) return 0
+
+    const periodEnd = new Date()
+    const periodStart = subMonths(periodEnd, 12)
+
+    // Active clients during the period, filtered by `created_at` and `is_active`
+    const activeClientsAtEnd = data.filter(
+      (client) =>
+        client.is_account_active && new Date(client.created_at) <= periodEnd,
+    ).length
+
+    // Clients who existed at the start of the period
+    const clientsAtStart = data.filter(
+      (client) => new Date(client.created_at) <= periodStart,
+    ).length
+
+    const newClientsDuringPeriod = data.filter(
+      (client) =>
+        new Date(client.created_at) > periodStart &&
+        new Date(client.created_at) <= periodEnd,
+    ).length
+
+    // Retention Rate Calculation
+    const retentionRate =
+      ((activeClientsAtEnd - newClientsDuringPeriod) / clientsAtStart) * 100
+
+    return Math.round(retentionRate) // Returns as a rounded number
+  }, [data])
+
+  const chartData = useMemo(
+    () => [
+      {
+        browser: 'safari',
+        retentionRate: retentionRate,
+        fill: 'var(--color-safari)',
+      },
+    ],
+    [retentionRate],
+  )
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className="mx-auto aspect-square max-h-[250px]"
+    >
+      <RadialBarChart
+        data={chartData}
+        innerRadius={80}
+        outerRadius={110}
+        endAngle={(chartData[0].retentionRate / 100) * 360}
+      >
+        <PolarGrid
+          gridType="circle"
+          radialLines={false}
+          stroke="none"
+          className="first:fill-muted last:fill-background"
+          polarRadius={[86, 74]}
+        />
+        <RadialBar dataKey="retentionRate" background cornerRadius={10} />
+        <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
+          <Label
+            content={({ viewBox }) => {
+              if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                return (
+                  <text
+                    x={viewBox.cx}
+                    y={viewBox.cy}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                  >
+                    <tspan
+                      x={viewBox.cx}
+                      y={viewBox.cy}
+                      className="fill-foreground text-4xl font-bold"
+                    >
+                      {chartData[0].retentionRate}%
+                    </tspan>
+                    <tspan
+                      x={viewBox.cx}
+                      y={(viewBox.cy || 0) + 24}
+                      className="fill-muted-foreground"
+                    >
+                      Retention Rate
+                    </tspan>
+                  </text>
+                )
+              }
+            }}
+          />
+        </PolarRadiusAxis>
+      </RadialBarChart>
+    </ChartContainer>
+  )
+}
+
+export default RetentionRateChart


### PR DESCRIPTION
### TL;DR
Added a new Retention Rate card component to the dashboard that displays client retention metrics in a radial chart format.

### What changed?
- Created a new RetentionRateCard component with a radial chart visualization
- Added chart configuration for retention rate display
- Implemented retention rate calculation logic using account data from Supabase
- Integrated the new card into the dashboard layout

### How to test?
1. Navigate to the dashboard page
2. Verify the Retention Rate card appears with a radial chart
3. Confirm the retention rate percentage is calculated correctly based on:
   - Active clients at period end
   - Clients at period start
   - New clients during the period
4. Check that the date range displays correctly (last 12 months)
5. Verify the chart updates when account data changes

### Why make this change?
This addition provides valuable insights into client retention metrics, helping businesses track and visualize their customer retention performance over a 12-month period. The radial chart format offers an intuitive way to understand retention rates at a glance.