### PR TITLE
feat(dashboard): add top agents leaderboard card

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@next/bundle-analyzer": "^14.2.3",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   '@radix-ui/react-alert-dialog':
     specifier: ^1.0.5
     version: 1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-avatar':
+    specifier: ^1.1.1
+    version: 1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-checkbox':
     specifier: ^1.0.4
     version: 1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
@@ -3290,6 +3293,29 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-avatar@1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-eoOtThOmxeoizxpX6RiEsQZ2wj5r4+zoeqAwO0cBaFQGjJwIH3dIX0OCxNrCyrrdxG+vBweMETh3VziQG7c1kw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.8)(react@18.2.0)
+      '@types/react': 18.2.8
+      '@types/react-dom': 18.2.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-checkbox@1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-0i/EKJ222Afa1FE0C6pNJxDq1itzcl3HChE9DwskA4th4KRse8ojx8a1nVcOjwJdbpDLcz7uol77yYnQNMHdKw==}
     peerDependencies:
@@ -3382,6 +3408,19 @@ packages:
 
   /@radix-ui/react-context@1.1.0(@types/react@18.2.8)(react@18.2.0):
     resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.8
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-context@1.1.1(@types/react@18.2.8)(react@18.2.0):
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc

--- a/src/app/(dashboard)/(home)/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/loading.tsx
@@ -3,10 +3,7 @@ import PageTitle from '@/app/(dashboard)/(home)/(dashboard)/page-title'
 const HomeLoading = () => {
   return (
     <div className="p-6">
-      <PageTitle
-        title="Mock Dashboard"
-        description="Welcome to the dashboard"
-      />
+      <PageTitle title="Dashboard" description="Welcome to the dashboard" />
     </div>
   )
 }

--- a/src/app/(dashboard)/(home)/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/page.tsx
@@ -5,6 +5,7 @@ import PageTitle from './page-title'
 import PreviousStatement from './previous-statement'
 import { Metadata } from 'next'
 import RetentionRateCard from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card'
+import TopAgentsCard from '@/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card'
 
 export const metadata = async (): Promise<Metadata> => {
   return {
@@ -15,15 +16,11 @@ export const metadata = async (): Promise<Metadata> => {
 const Dashboard = () => {
   return (
     <div className="p-6">
-      <PageTitle
-        title="Mock Dashboard"
-        description="Welcome to the dashboard"
-      />
+      <PageTitle title="Dashboard" description="Welcome to the dashboard" />
       <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-2">
         <ClientAcquisitionCard />
         <RetentionRateCard />
-        <PreviousStatement />
-        <PreviousStatement />
+        <TopAgentsCard />
       </div>
     </div>
   )

--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-chart.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import chartConfig from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/chart-config'
-import { ChartConfig, ChartContainer } from '@/components/ui/chart'
+import { ChartContainer } from '@/components/ui/chart'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import { subMonths, subYears } from 'date-fns'
+import { subMonths } from 'date-fns'
 import { useMemo } from 'react'
 import {
   Label,

--- a/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card.tsx
@@ -1,0 +1,32 @@
+import TopAgentsList from '@/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-list'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { format, subMonths } from 'date-fns'
+
+const TopAgentsCard = () => {
+  const last12Months = subMonths(new Date(), 12)
+
+  return (
+    <Card className="col-span-1">
+      <CardHeader>
+        <CardTitle className="flex flex-row items-center justify-between">
+          <span className="text-base font-medium">Top Agents</span>
+          <Badge variant="default" className="bg-muted text-muted-foreground">
+            Last 12 Months
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TopAgentsList />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default TopAgentsCard

--- a/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-list.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-list.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { Badge } from '@/components/ui/badge'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { subMonths } from 'date-fns'
+import { Users } from 'lucide-react'
+import dynamic from 'next/dynamic'
+import { useMemo } from 'react'
+import { genConfig } from 'react-nice-avatar'
+
+const Avatar = dynamic(() => import('react-nice-avatar'), { ssr: false })
+
+const TopAgentsList = () => {
+  const supabase = createBrowserClient()
+
+  const { data } = useQuery(
+    supabase
+      .from('user_profiles')
+      .select(
+        'user_id, first_name, last_name, departments(name), accounts(created_at)',
+      )
+      .eq('departments.name', 'agent')
+      .throwOnError(),
+  )
+
+  const topAgents = useMemo(() => {
+    if (!data) return []
+
+    const periodStart = subMonths(new Date(), 12)
+
+    return data
+      .map((agent) => ({
+        ...agent,
+        recentAccountsCount: agent.accounts.filter(
+          (account) => new Date(account.created_at) >= periodStart,
+        ).length,
+      }))
+      .sort((a, b) => b.recentAccountsCount - a.recentAccountsCount)
+      .slice(0, 5)
+  }, [data])
+
+  return (
+    <div className="space-y-4">
+      {topAgents.map((agent, index) => {
+        const config = genConfig(agent.user_id)
+
+        return (
+          <div key={agent.user_id} className="flex items-center space-x-4">
+            <Badge
+              variant="secondary"
+              className="flex h-6 w-6 flex-row items-center justify-center rounded-full bg-muted text-muted-foreground"
+            >
+              {index + 1}
+            </Badge>
+            <Avatar className="h-10 w-10" {...config} />
+            <div className="flex-1 space-y-1">
+              <h3 className="font-semibold">
+                {agent.first_name} {agent.last_name}
+              </h3>
+              <div className="flex items-center space-x-2">
+                <Users className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm">
+                  {agent.recentAccountsCount} Clients
+                </span>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default TopAgentsList

--- a/src/app/(dashboard)/admin/agents/agents-list.tsx
+++ b/src/app/(dashboard)/admin/agents/agents-list.tsx
@@ -79,9 +79,7 @@ const AgentsListItem = ({
         </div>
         <div>
           <Suspense
-            fallback={
-              <Skeleton className="mx-6 h-32 w-32 rounded-full rounded-full" />
-            }
+            fallback={<Skeleton className="mx-6 h-32 w-32 rounded-full" />}
           >
             <Avatar
               className="mx-6 h-32 w-32 -translate-y-16 rounded-full border-4 border-card"

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import * as React from 'react'
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+
+import { cn } from '@/utils/tailwind'
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
+      className,
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn('aspect-square h-full w-full', className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      'flex h-full w-full items-center justify-center rounded-full bg-muted',
+      className,
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }


### PR DESCRIPTION
### TL;DR
Added a new Top Agents card to the dashboard displaying the most active agents over the last 12 months.

### What changed?
- Added a new Top Agents card component showing the top 5 performing agents
- Integrated react-nice-avatar for agent avatars
- Added Radix UI Avatar component
- Updated dashboard title from "Mock Dashboard" to "Dashboard"
- Removed duplicate PreviousStatement components

### How to test?
1. Navigate to the dashboard
2. Verify the Top Agents card appears with a list of agents
3. Confirm each agent displays:
   - Ranking number (1-5)
   - Avatar
   - Full name
   - Number of clients acquired in the last 12 months
4. Verify the data sorts correctly by number of clients

### Why make this change?
This addition provides valuable visibility into agent performance, helping identify and recognize top performers based on client acquisition metrics. The visual representation makes it easy for managers to quickly assess agent productivity over the past year.