### PR TITLE
feat(accounts): improve company delete functionality and UI

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -2,7 +2,6 @@ import CompanyAccountInformation from '@/app/(dashboard)/(home)/accounts/(Person
 import CompanyCancelButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-cancel-button'
 import CompanyContractInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information'
 import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
-
 import CompanyHMOInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information'
 import CompanyInformation from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information'
 import accountsSchema from '@/app/(dashboard)/(home)/accounts/accounts-schema'

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-button.tsx
@@ -27,14 +27,17 @@ const CompanyEditButton: FC<Props> = ({ role }) => {
   const supabase = createBrowserClient()
 
   const handleClick = useCallback(async () => {
+    // check if there is already a pending request
     const { data } = await supabase
       .from('pending_accounts')
       .select('id')
       .eq('account_id', accountId)
       .eq('is_active', true)
       .eq('is_approved', false)
-      .single()
+      .limit(1)
+      .maybeSingle()
 
+    // if there is already a pending request, open the edit pending request modal
     if (data) {
       setIsEditPendingRequestOpen(true)
       setPendingRequestId(data.id)

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-page.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-page.tsx
@@ -3,13 +3,13 @@
 import CompanyAbout from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about'
 import CompanyEditButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-button'
 import CompanyEditProvider from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
-import CompanyHeader from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
-import { Tabs, TabsContent } from '@/components/ui/tabs'
-import { FC, useEffect } from 'react'
-import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
-import dynamic from 'next/dynamic'
 import CompanyDeleteButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/delete/company-delete-button'
+import CompanyHeader from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header'
+import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
+import { Tabs, TabsContent } from '@/components/ui/tabs'
+import dynamic from 'next/dynamic'
+import { FC, useEffect } from 'react'
 
 interface Props {
   companyId: string
@@ -54,17 +54,11 @@ const CompanyPage: FC<Props> = ({ companyId, role }) => {
           <CompanyEditProvider>
             <div className="flex w-full flex-row items-center gap-2 pb-4 sm:justify-end">
               <CompanyEditButton role={role} />
-              {[
-                'marketing',
-                'finance',
-                'admin',
-                'under-sales',
-                'after-sales',
-              ].includes(role || '') && (
-                <CompanyDeleteButton accountId={companyId} />
-              )}
             </div>
             <CompanyAbout companyId={companyId} />
+            <div className="flex w-full justify-end md:justify-start">
+              <CompanyDeleteButton accountId={companyId} />
+            </div>
           </CompanyEditProvider>
         </TabsContent>
         <TabsContent value="employees">

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/delete/company-delete-button.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/delete/company-delete-button.tsx
@@ -1,5 +1,6 @@
 'use client'
-import EditPendingRequest from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/edit-pending-request'
+import { useCompanyEditContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-edit-provider'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
 import { AlertDialog, AlertDialogTrigger } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Trash } from 'lucide-react'
@@ -14,41 +15,61 @@ const CompanyDeleteForm = dynamic(
   { ssr: false },
 )
 
+const EditPendingRequest = dynamic(
+  () =>
+    import(
+      '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/edit-pending-request'
+    ),
+  { ssr: false },
+)
+
 interface Props {
   accountId: string
 }
 
 const CompanyDeleteButton: FC<Props> = ({ accountId }) => {
   const [isOpen, setIsOpen] = useState(false)
+  const { userRole } = useCompanyContext()
+  const { editMode } = useCompanyEditContext()
 
   const [isEditPendingRequestOpen, setIsEditPendingRequestOpen] =
     useState(false)
   const [pendingRequestId, setPendingRequestId] = useState('')
 
-  return (
-    <>
-      <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
-        <AlertDialogTrigger asChild={true}>
-          <Button className="w-fit" variant={'destructive'}>
-            <Trash />
-          </Button>
-        </AlertDialogTrigger>
+  if (
+    ['marketing', 'finance', 'admin', 'under-sales', 'after-sales'].includes(
+      userRole || '',
+    ) &&
+    !editMode
+  ) {
+    return (
+      <>
+        <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+          <AlertDialogTrigger asChild={true}>
+            <Button variant={'link'} className="text-red-500" type="button">
+              <Trash className="mr-2" /> Delete Account
+            </Button>
+          </AlertDialogTrigger>
+          <Suspense fallback={<div>Loading...</div>}>
+            <CompanyDeleteForm
+              accountId={accountId}
+              setIsOpen={setIsOpen}
+              setIsEditPendingRequestOpen={setIsEditPendingRequestOpen}
+              setPendingRequestId={setPendingRequestId}
+            />
+          </Suspense>
+        </AlertDialog>
         <Suspense fallback={<div>Loading...</div>}>
-          <CompanyDeleteForm
-            accountId={accountId}
-            setIsOpen={setIsOpen}
-            setIsEditPendingRequestOpen={setIsEditPendingRequestOpen}
-            setPendingRequestId={setPendingRequestId}
+          <EditPendingRequest
+            isOpen={isEditPendingRequestOpen}
+            onClose={() => setIsEditPendingRequestOpen(false)}
+            pendingRequestId={pendingRequestId}
           />
         </Suspense>
-      </AlertDialog>
-      <EditPendingRequest
-        isOpen={isEditPendingRequestOpen}
-        onClose={() => setIsEditPendingRequestOpen(false)}
-        pendingRequestId={pendingRequestId}
-      />
-    </>
-  )
+      </>
+    )
+  }
+  return null
 }
 
 export default CompanyDeleteButton

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/delete/company-delete-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/delete/company-delete-form.tsx
@@ -93,6 +93,14 @@ const CompanyDeleteForm: FC<Props> = ({
           return
         }
 
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+
+        if (!user) {
+          return
+        }
+
         // check if there is already a pending request
         const { data: pendingRequest } = await supabase
           .from('pending_accounts')
@@ -100,17 +108,15 @@ const CompanyDeleteForm: FC<Props> = ({
           .eq('account_id', accountId)
           .eq('is_active', true)
           .eq('is_approved', false)
-          .single()
+          .eq('created_by', user?.id)
+          .limit(1)
+          .maybeSingle()
 
         if (pendingRequest) {
           setIsEditPendingRequestOpen(true)
           setPendingRequestId(pendingRequest.id)
-          return
+          return Error('Request already exists')
         }
-
-        const {
-          data: { user },
-        } = await supabase.auth.getUser()
 
         await mutateAsync([
           {


### PR DESCRIPTION
### TL;DR
Enhanced company account deletion functionality and improved pending request handling

### What changed?
- Relocated delete button to bottom of company profile and updated its styling
- Added user role validation for delete button visibility
- Improved pending request checks to use `maybeSingle()` instead of `single()`
- Added validation to ensure users can't create duplicate pending requests
- Prevented delete button from showing during edit mode
- Added user authentication check before processing delete requests

### How to test?
1. Log in with different user roles to verify delete button visibility
2. Attempt to delete a company account and verify the confirmation modal
3. Try creating multiple delete requests to ensure duplicates are prevented
4. Verify delete button is hidden during edit mode
5. Test with an unauthenticated session to ensure proper error handling

### Why make this change?
To improve user experience and system security by:
- Making the delete action more prominent yet safer
- Preventing duplicate deletion requests
- Ensuring only authorized users can access deletion functionality
- Adding proper validation checks before processing deletions