### PR TITLE
TIM-676 Add requests lists for employee requests tab

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-request-list.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-request-list.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import { createBrowserClient } from '@/utils/supabase'
+import getPendingEmployeeExports from '@/queries/get-pending-employee-exports'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import EmployeeExportRequestsListItem from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests-list-item'
+
+const EmployeeExportRequestList = () => {
+  const { accountId } = useCompanyContext()
+  const supabase = createBrowserClient()
+
+  const { data: pendingEmployeeExports } = useQuery(
+    getPendingEmployeeExports(supabase, accountId, 'employees'),
+  )
+
+  console.log(pendingEmployeeExports)
+
+  return (
+    <div className="grid grid-cols-1 divide-y">
+      {pendingEmployeeExports?.map((pendingExports) => (
+        <EmployeeExportRequestsListItem
+          key={pendingExports.id}
+          data={pendingExports as any}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default EmployeeExportRequestList

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests-list-item.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests-list-item.tsx
@@ -1,7 +1,26 @@
-import React from 'react'
+import React, { FC } from 'react'
+import { Tables } from '@/types/database.types'
+import { formatDistanceToNow } from 'date-fns'
 
-const EmployeeExportRequestsListItem = () => {
-  return <div></div>
+interface EmployeeExportRequestsListItemProps {
+  data: Tables<'pending_export_requests'>
+}
+const EmployeeExportRequestsListItem: FC<
+  EmployeeExportRequestsListItemProps
+> = ({ data }) => {
+  return (
+    <div className="grid grid-cols-2 items-center gap-2 px-2 py-6">
+      <p className="text-sm font-medium">
+        {(data.created_by as any).first_name}{' '}
+        {(data.created_by as any).last_name}
+      </p>
+      <span className="ml-auto w-fit text-sm text-muted-foreground">
+        {formatDistanceToNow(new Date(data.created_at), {
+          addSuffix: true,
+        })}
+      </span>
+    </div>
+  )
 }
 
 export default EmployeeExportRequestsListItem

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests.tsx
@@ -8,11 +8,11 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import EmployeeRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getPendingEmployeeExports from '@/queries/get-pending-employee-exports'
+import EmployeeExportRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-request-list'
 
 const EmployeeExportRequests = () => {
   const { accountId } = useCompanyContext()
@@ -29,7 +29,6 @@ const EmployeeExportRequests = () => {
           size={'sm'}
           className="flex h-8 w-fit rounded-none"
         >
-          {/* TODO: add count */}
           {count} Export Requests
         </Button>
       </DialogTrigger>
@@ -40,7 +39,7 @@ const EmployeeExportRequests = () => {
             View and manage export requests and submissions
           </DialogDescription>
         </DialogHeader>
-        <EmployeeRequestList />
+        <EmployeeExportRequestList />
       </DialogContent>
     </Dialog>
   )

--- a/src/queries/get-pending-employee-exports.tsx
+++ b/src/queries/get-pending-employee-exports.tsx
@@ -8,10 +8,12 @@ const getPendingEmployeeExports = (
 ) => {
   return supabase
     .from('pending_export_requests')
-    .select(`id, export_type`, {
-      count: 'exact',
-      head: true,
-    })
+    .select(
+      `id, export_type, created_at, created_by(first_name, last_name, user_id)`,
+      {
+        count: 'exact',
+      },
+    )
     .eq('is_approved', false)
     .eq('is_active', true)
     .eq('export_type', exportType)


### PR DESCRIPTION
### TL;DR
I'm tired i hate backend dev >:(
Added functionality to display pending employee export requests with user details and timestamps.

### What changed?
- Created a new employee export request list component to display pending exports
- Enhanced the export request list item to show requester's name and time since request
- Updated the pending employee exports query to fetch additional user details
- Integrated the export request list into the export requests dialog

### How to test?
1. Navigate to the employee section
2. Click on "Export Requests" button
3. Verify that pending export requests are displayed with:
   - Requester's full name
   - Time since request was made
4. Confirm that the count of pending requests is accurate

### Why make this change?
To provide users with visibility into pending export requests and their status, allowing better tracking and management of employee data export operations.