### PR TITLE
feat(import): improve date parsing and case matching

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/fields.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/fields.ts
@@ -86,12 +86,12 @@ const importFields = [
         {
           label: 'Male',
           value: 'male',
-          alternateMatches: ['male', 'm'],
+          alternateMatches: ['male', 'm', 'MALE'],
         },
         {
           label: 'Female',
           value: 'female',
-          alternateMatches: ['female', 'f'],
+          alternateMatches: ['female', 'f', 'FEMALE'],
         },
       ],
     },
@@ -107,22 +107,22 @@ const importFields = [
         {
           label: 'Single',
           value: 'single',
-          alternateMatches: ['Single', 'single'],
+          alternateMatches: ['Single', 'single', 'SINGLE'],
         },
         {
           label: 'Married',
           value: 'married',
-          alternateMatches: ['Married', 'married'],
+          alternateMatches: ['Married', 'married', 'MARRIED'],
         },
         {
           label: 'Divorced',
           value: 'divorced',
-          alternateMatches: ['Divorced', 'divorced', 'divorce'],
+          alternateMatches: ['Divorced', 'divorced', 'divorce', 'DIVORCED'],
         },
         {
           label: 'Widowed',
           value: 'widowed',
-          alternateMatches: ['Widowed', 'widowed'],
+          alternateMatches: ['Widowed', 'widowed', 'WIDOWED'],
         },
       ],
     },

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/parseDate.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/parseDate.ts
@@ -7,8 +7,10 @@ const parseDate = (data: RawData[]): Promise<RawData[]> => {
       return row.map((cell) => {
         if (
           typeof cell === 'string' &&
+          !/\d{1,2}\/\d{1,2}\/\d{4} to \d{1,2}\/\d{1,2}\/\d{4}/.test(cell) &&
           (/\d{1,2}\/\d{1,2}\/\d{4}/.test(cell) ||
-            /\d{1,2} \w{3} \d{4}/.test(cell))
+            /\d{1,2} \w{3} \d{4}/.test(cell) ||
+            /\d{1}\/\d{2}\/\d{4}/.test(cell))
         ) {
           return format(new Date(cell), 'MM/dd/yyyy')
         }


### PR DESCRIPTION
### TL;DR
Added support for additional date formats and case-insensitive gender/marital status matching in employee import functionality.

### What changed?
- Added uppercase variants for gender options (MALE, FEMALE)
- Added uppercase variants for marital status options (SINGLE, MARRIED, DIVORCED, WIDOWED)
- Enhanced date parsing to support:
  - Single-digit month format (e.g., 1/02/2024)
  - Date range exclusion (e.g., "1/1/2024 to 1/2/2024")

### How to test?
1. Import employee data with:
   - Uppercase gender values (MALE, FEMALE)
   - Uppercase marital status values (SINGLE, MARRIED, etc.)
   - Dates in single-digit month format (1/02/2024)
   - Date ranges to verify they're not incorrectly parsed
2. Verify all values are correctly imported and formatted

### Why make this change?
To improve data import flexibility by accommodating more common data formats and variations in how gender and marital status information might be formatted in source files, reducing import errors and manual data cleanup.