### PR TITLE
feat(accounts): add company address accessor

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
+++ b/src/app/(dashboard)/(home)/accounts/columns/accounts-columns.tsx
@@ -68,6 +68,7 @@ const accountsColumns: ColumnDef<Tables<'accounts'>>[] = [
     header: ({ column }) => (
       <TableHeader column={column} title="Company Address" />
     ),
+    accessorFn: (originalRow) => (originalRow as any)?.company_address ?? '',
   },
   {
     accessorKey: 'nature_of_business',


### PR DESCRIPTION
### TL;DR
Added accessor function for company address column in accounts table

### What changed?
Added an `accessorFn` to properly handle and display company addresses in the accounts table, including fallback to empty string when address is undefined

### How to test?
1. Navigate to the accounts table
2. Verify company addresses are displayed correctly
3. Check that empty/undefined addresses show as blank cells instead of errors

### Why make this change?
To prevent potential rendering issues when company addresses are undefined and ensure consistent display of address data in the accounts table