### PR TITLE
feat(employees): add actions dropdown menu

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
@@ -1,0 +1,53 @@
+import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-form-modal'
+import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
+import EllipsisVertical from '@/assets/icons/ellipsis-vertical'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { FileDown, Plus } from 'lucide-react'
+
+const EmployeeActionsDropdown = () => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <EllipsisVertical />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuGroup>
+          <DropdownMenuItem asChild={true}>
+            <EmployeeFormModal
+              button={
+                <div className="relative flex cursor-pointer select-none items-center gap-1.5 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+                  <Plus className="h-4 w-4" />
+                  <span>Add Employee</span>
+                </div>
+              }
+            />
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild={true}>
+            <EmployeeExportModal
+              exportData="employees"
+              button={
+                <div className="relative flex cursor-pointer select-none items-center gap-1.5 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+                  <FileDown className="h-4 w-4" />
+                  <span>Export Employees</span>
+                </div>
+              }
+            />
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default EmployeeActionsDropdown

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
@@ -31,6 +31,7 @@ import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
 import EmployeeExportRequests from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests'
+import EmployeeActionsDropdown from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -68,15 +69,16 @@ const EmployeesDataTable = <TData, TValue>({
       <div className="flex flex-row items-center justify-between gap-2 py-4">
         <EmployeesTableSearch table={table} />
         <div className="flex items-center space-x-1">
-          <EmployeeFormModal
+          {/* <EmployeeFormModal
             button={
               <Button className="gap-2">
                 <Plus /> <span> Add Employee </span>
               </Button>
             }
-          />
+          /> */}
           <ImportEmployeesButton />
-          <EmployeeExportModal exportData={'employees'} />
+          {/* <EmployeeExportModal exportData={'employees'} /> */}
+          <EmployeeActionsDropdown />
         </div>
       </div>
       <div className="flex flex-row">

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react'
+import React, { FC, ReactNode, useCallback } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -19,9 +19,13 @@ import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)
 
 interface EmployeeExportModalProps {
   exportData: Enums<'export_type'>
+  button: ReactNode
 }
 
-const EmployeeExportModal: FC<EmployeeExportModalProps> = ({ exportData }) => {
+const EmployeeExportModal: FC<EmployeeExportModalProps> = ({
+  exportData,
+  button,
+}) => {
   const [isOpen, setIsOpen] = useState(false)
   const [isDeleteOpen, setIsDeleteOpen] = useState(false)
   const [pendingRequests, setPendingRequests] = useState('')
@@ -74,7 +78,7 @@ const EmployeeExportModal: FC<EmployeeExportModalProps> = ({ exportData }) => {
     } else {
       setIsOpen(true)
     }
-  }, [exportData, supabase])
+  }, [accountId, exportData, supabase])
 
   const handleConfirm = async () => {
     const {
@@ -92,14 +96,7 @@ const EmployeeExportModal: FC<EmployeeExportModalProps> = ({ exportData }) => {
 
   return (
     <>
-      <Button
-        className="space-x-2"
-        variant={'outline'}
-        onClick={handleApproval}
-      >
-        <FileDown />
-        <span>Export</span>
-      </Button>
+      <div onClick={handleApproval}>{button}</div>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent className="max-h-[80vh] overflow-y-auto">
           <DialogHeader>

--- a/src/assets/icons/ellipsis-vertical.tsx
+++ b/src/assets/icons/ellipsis-vertical.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { SVGProps } from 'react'
+const EllipsisVertical = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2}
+    className="lucide lucide-ellipsis-vertical"
+    {...props}
+  >
+    <circle cx={12} cy={12} r={1} />
+    <circle cx={12} cy={5} r={1} />
+    <circle cx={12} cy={19} r={1} />
+  </svg>
+)
+export default EllipsisVertical


### PR DESCRIPTION
### TL;DR
Replaced employee action buttons with a dropdown menu for better UI organization.

### What changed?
- Created a new `EmployeeActionsDropdown` component with a vertical ellipsis menu
- Moved "Add Employee" and "Export Employees" actions into the dropdown menu
- Added a new `EllipsisVertical` icon component
- Updated the `EmployeeExportModal` to accept a custom button prop for flexibility
- Replaced the standalone action buttons in the employees data table with the new dropdown

### How to test?
1. Navigate to the employees table view
2. Verify the vertical ellipsis menu appears in the top right
3. Click the menu and confirm both "Add Employee" and "Export Employees" options are present
4. Test each action to ensure they function as expected:
   - Adding a new employee
   - Exporting employee data

### Why make this change?
This change improves the UI by consolidating actions into a cleaner dropdown menu, reducing visual clutter and providing a more organized interface for user interactions. The dropdown pattern is more scalable for adding future actions without compromising the layout.