### PR TITLE
TIM-685 feat(employees): add clear all employees

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/clear-employee-requests.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/clear-employee-requests.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/components/ui/use-toast'
+import getPendingEmployeeByCompanyId from '@/queries/get-pending-employee-by-company-id'
+import { createBrowserClient } from '@/utils/supabase'
+import {
+  useQuery,
+  useUpsertMutation,
+} from '@supabase-cache-helpers/postgrest-react-query'
+import { useState } from 'react'
+
+const ClearEmployeeRequests = () => {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const supabase = createBrowserClient()
+  const { accountId } = useCompanyContext()
+
+  const { data: pendingEmployees } = useQuery(
+    getPendingEmployeeByCompanyId(supabase, accountId),
+  )
+
+  const { mutateAsync: deletePendingEmployees, isPending } = useUpsertMutation(
+    // @ts-ignore
+    supabase.from('pending_company_employees'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Requests cleared!',
+          description: 'Successfully cleared requests',
+        })
+      },
+      onError: (err: any) => {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: err.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = () => {
+    // if confirmDelete is false, set it to true
+    if (confirmDelete === false) {
+      setConfirmDelete(true)
+      return
+    } else {
+      // if confirmDelete is true, delete the requests
+      if (pendingEmployees) {
+        deletePendingEmployees([
+          ...pendingEmployees.map((employee) => ({
+            id: employee.id,
+            is_active: false,
+            account_id: accountId,
+            first_name: employee.first_name,
+            last_name: employee.last_name,
+            gender: employee?.gender,
+            civil_status: employee?.civil_status,
+            card_number: employee?.card_number,
+            effective_date: employee?.effective_date,
+            room_plan: employee?.room_plan,
+            maximum_benefit_limit: employee?.maximum_benefit_limit,
+            birth_date: employee?.birth_date,
+            created_by: (employee.created_by as any).user_id,
+            operation_type: employee?.operation_type,
+            batch_id: employee?.batch_id,
+            updated_at: new Date().toISOString(),
+          })),
+        ])
+        setConfirmDelete(false)
+      }
+    }
+  }
+
+  return (
+    <Button
+      variant={'link'}
+      size={'sm'}
+      className="text-xs text-destructive"
+      onClick={handleDelete}
+      disabled={isPending || pendingEmployees?.length === 0}
+    >
+      {confirmDelete ? 'Are you sure?' : 'Clear Requests'}
+    </Button>
+  )
+}
+
+export default ClearEmployeeRequests

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/delete-employee-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/delete-employee-request.tsx
@@ -42,6 +42,7 @@ const DeleteEmployeeRequest = ({ data }: DeleteEmployeeRequestProps) => {
     updatePendingEmployee({
       id: data.id,
       is_active: false,
+      updated_at: new Date().toISOString(),
     })
   }
   return (

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import ClearEmployeeRequests from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/clear-employee-requests'
 import EmployeeRequestList from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request-list'
 import { Button } from '@/components/ui/button'
 import {
@@ -13,7 +14,6 @@ import {
 import getPendingEmployeeByCompanyId from '@/queries/get-pending-employee-by-company-id'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import getPendingEmployeeExports from '@/queries/get-pending-employee-exports'
 
 const EmployeeRequest = () => {
   const { accountId } = useCompanyContext()
@@ -28,15 +28,15 @@ const EmployeeRequest = () => {
           size={'sm'}
           className="flex h-8 w-full rounded-none"
         >
-          {/* TODO: add count */}
           {count} Employee Requests
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Submission Requests</DialogTitle>
-          <DialogDescription>
-            View and manage employee requests and submissions
+          <DialogDescription className="flex items-start justify-between gap-2">
+            <span>View and manage employee requests and submissions</span>
+            <ClearEmployeeRequests />
           </DialogDescription>
         </DialogHeader>
         <EmployeeRequestList />


### PR DESCRIPTION
### TL;DR
Added functionality to clear all employee requests in bulk and improved request deletion tracking.

### What changed?
- Created new `ClearEmployeeRequests` component with confirmation dialog
- Added `updated_at` timestamp tracking for request deletions
- Integrated bulk clear functionality in the employee requests dialog
- Added disable state for clear button when no requests exist

### How to test?
1. Navigate to employee requests dialog
2. Verify "Clear Requests" button appears in dialog header
3. Click "Clear Requests" to see confirmation prompt
4. Confirm deletion to remove all pending requests
5. Verify toast notification appears on successful deletion
6. Check that button is disabled when no requests exist

### Why make this change?
To provide administrators with an efficient way to manage employee requests by allowing them to clear multiple pending requests simultaneously, rather than deleting them one by one. This also improves request tracking by maintaining deletion timestamps.