### PR TITLE
feat(employees): add bulk delete functionality

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
@@ -1,3 +1,4 @@
+import DeleteAllEmployees from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/delete-all-employees'
 import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form-modal'
 import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
 import EllipsisVertical from '@/assets/icons/ellipsis-vertical'
@@ -10,7 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { FileDown, Plus } from 'lucide-react'
+import { FileDown, Plus, Trash2 } from 'lucide-react'
 
 const EmployeeActionsDropdown = () => {
   return (
@@ -45,11 +46,16 @@ const EmployeeActionsDropdown = () => {
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        {/* <DropdownMenuGroup>
-          <DropdownMenuItem asChild={true}>
-
-          </DropdownMenuItem>
-        </DropdownMenuGroup> */}
+        <DropdownMenuGroup>
+          <DeleteAllEmployees
+            button={
+              <DropdownMenuItem className="relative flex cursor-pointer select-none items-center gap-1.5 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+                <Trash2 className="h-4 w-4" />
+                <span>Delete All Employees</span>
+              </DropdownMenuItem>
+            }
+          />
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/delete-all-employees.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/delete-all-employees.tsx
@@ -1,0 +1,109 @@
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import ConfirmationDialog from '@/components/confirmation-dialog/confirmation-dialog'
+import useConfirmationStore from '@/components/confirmation-dialog/confirmationStore'
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
+import { toast } from '@/components/ui/use-toast'
+import getEmployeeByCompanyId from '@/queries/get-employee-by-company-id'
+import { createBrowserClient } from '@/utils/supabase'
+import {
+  useInsertMutation,
+  useQuery,
+} from '@supabase-cache-helpers/postgrest-react-query'
+import { FC, ReactNode } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+interface DeleteAllEmployeesProps {
+  button: ReactNode
+}
+
+const DeleteAllEmployees: FC<DeleteAllEmployeesProps> = ({ button }) => {
+  const { openConfirmation } = useConfirmationStore()
+  const supabase = createBrowserClient()
+  const { accountId } = useCompanyContext()
+
+  // get all employees
+  const { data: employees } = useQuery(
+    getEmployeeByCompanyId(supabase, accountId),
+  )
+
+  const { mutateAsync, isPending } = useInsertMutation(
+    // @ts-ignore
+    supabase.from('pending_company_employees'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          variant: 'default',
+          title: 'Employee deletion request submitted!',
+          description:
+            'Your request to delete all employees has been submitted successfully and is awaiting approval.',
+        })
+      },
+      onError: (error) => {
+        toast({
+          variant: 'destructive',
+          title: 'Something went wrong',
+          description: error.message,
+        })
+      },
+    },
+  )
+
+  const handleDelete = async () => {
+    // check if employees exist
+    if (!employees) return
+
+    // get user
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) return
+
+    // generate a batch id
+    const batchId = uuidv4()
+
+    // insert "delete request" for each employee
+    await mutateAsync(
+      employees?.map((employee) => ({
+        account_id: accountId,
+        first_name: employee.first_name,
+        last_name: employee.last_name,
+        birth_date: employee.birth_date,
+        gender: employee.gender,
+        civil_status: employee.civil_status,
+        card_number: employee.card_number,
+        effective_date: employee.effective_date,
+        room_plan: employee.room_plan,
+        maximum_benefit_limit: employee.maximum_benefit_limit,
+        company_employee_id: employee.id,
+        operation_type: 'delete',
+        is_delete_employee: true,
+        is_active: true,
+        created_by: user.id,
+        batch_id: batchId,
+      })),
+    )
+  }
+
+  return (
+    <div
+      onClick={() => {
+        openConfirmation({
+          title: 'Delete All Employees?',
+          description:
+            'Are you sure you want to delete all employees? This action CANNOT be undone.',
+          actionLabel: 'I understand, delete all employees',
+          cancelLabel: 'Cancel',
+          onAction: handleDelete,
+          onCancel: () => {},
+        })
+      }}
+    >
+      {button}
+    </div>
+  )
+}
+
+export default DeleteAllEmployees

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-data-table.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form-modal'
+import EmployeeActionsDropdown from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown'
 import EmployeesTableSearch from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employees-table-search'
-import ExportEmployees from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-employees'
+import EmployeeExportRequests from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests'
 import ImportEmployeesButton from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/import-employees-button'
 import EmployeeRequest from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/request/employee-request'
 import TablePagination from '@/components/table-pagination'
-import { Button } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -26,12 +25,7 @@ import {
   useReactTable,
   VisibilityState,
 } from '@tanstack/react-table'
-import { Plus } from 'lucide-react'
-import dynamic from 'next/dynamic'
 import { useState } from 'react'
-import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
-import EmployeeExportRequests from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-requests'
-import EmployeeActionsDropdown from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown'
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -69,15 +63,7 @@ const EmployeesDataTable = <TData, TValue>({
       <div className="flex flex-row items-center justify-between gap-2 py-4">
         <EmployeesTableSearch table={table} />
         <div className="flex items-center space-x-1">
-          {/* <EmployeeFormModal
-            button={
-              <Button className="gap-2">
-                <Plus /> <span> Add Employee </span>
-              </Button>
-            }
-          /> */}
           <ImportEmployeesButton />
-          {/* <EmployeeExportModal exportData={'employees'} /> */}
           <EmployeeActionsDropdown />
         </div>
       </div>

--- a/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
@@ -65,9 +65,14 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
   const handleClick = async () => {
     if (!selectedData) return
     if (action === 'approve') {
+      // If its approved then we upsert the employee
       await upsertEmployee(
+        // Data is an array of items (batch)
         (selectedData as any)?.items
           ? (selectedData as any)?.items.map((item: any) => ({
+              ...(item.company_employee_id && {
+                id: item.company_employee_id,
+              }),
               account_id: item.account_id,
               first_name: item.first_name,
               last_name: item.last_name,
@@ -79,8 +84,10 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
               room_plan: item.room_plan,
               maximum_benefit_limit: item.maximum_benefit_limit,
               created_by: (item.created_by as any)?.user_id,
+              is_active: item.is_delete_employee ? false : true,
             }))
           : [
+              // Data is a single item
               {
                 ...(selectedData.company_employee_id && {
                   id: selectedData.company_employee_id,
@@ -107,14 +114,15 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
       })
     }
 
-    // Update pending employee
+    // Update pending employee either it is approved or rejected
+    // If the selected data is an array of items, then we need to update each item
     if ((selectedData as any)?.items) {
       await updatePendingEmployee(
         (selectedData as any).items.map(
           (item: Tables<'pending_company_employees'>) => ({
             id: item.id,
-            is_approved: action === 'approve',
-            is_active: action === 'approve',
+            is_approved: action === 'approve', // Approve or reject
+            is_active: action === 'approve', // Approve or reject
             created_by: (item.created_by as any)?.user_id,
             operation_type: item.operation_type,
             batch_id: item.batch_id,
@@ -136,11 +144,13 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
         })
       })
     } else {
+      // Update pending employee
+      // If the selected data is not an array of items, then we need to update the single item
       await updatePendingEmployee([
         {
           id: selectedData.id,
-          is_approved: action === 'approve',
-          is_active: action === 'approve',
+          is_approved: action === 'approve', // Approve or reject
+          is_active: action === 'approve', // Approve or reject
           created_by: (selectedData.created_by as any)?.user_id,
           operation_type: selectedData.operation_type,
           batch_id: selectedData.batch_id,

--- a/src/app/(dashboard)/admin/approval-request/company-employees/groupData.ts
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/groupData.ts
@@ -23,6 +23,7 @@ const groupData = (data: any) => {
         account: firstItem.account,
         created_at: firstItem.created_at,
         operation_type: firstItem.operation_type,
+        company_employee_id: firstItem.company_employee_id,
         first_name: '-',
         last_name: '-',
       })

--- a/supabase/migrations/20241110091956_add_RLS_for_admin_to_employees_table.sql
+++ b/supabase/migrations/20241110091956_add_RLS_for_admin_to_employees_table.sql
@@ -1,0 +1,13 @@
+create policy "Enable update access for admin"
+on "public"."company_employees"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added functionality to delete all employees in bulk through a new dropdown action, with admin approval workflow.

### What changed?
- Added "Delete All Employees" option to the employee actions dropdown
- Created new component to handle bulk employee deletion requests
- Implemented batch processing for employee deletion requests
- Added RLS policy to allow admin users to update employee records
- Enhanced approval workflow to handle bulk employee deletions
- Updated employee action handling to support is_active status changes

### How to test?
1. Navigate to the employees page
2. Click the actions dropdown menu
3. Select "Delete All Employees"
4. Confirm the deletion request
5. Login as admin to verify the deletion request appears in the approval queue
6. Approve/reject the deletion request
7. Verify employees are marked as inactive upon approval

### Why make this change?
To provide administrators with an efficient way to manage large-scale employee removals while maintaining proper approval workflows and data integrity. This feature streamlines the process of removing multiple employees simultaneously, reducing manual effort and potential errors.