### PR TITLE
feat(admin): add page titles to approval request views

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/accounts/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/page.tsx
@@ -12,6 +12,7 @@ import {
 import { cookies } from 'next/headers'
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
+import { Metadata } from 'next'
 
 const ApprovalRequestInfo = dynamic(
   () =>
@@ -20,6 +21,12 @@ const ApprovalRequestInfo = dynamic(
     ),
   { ssr: false },
 )
+
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Review Accounts',
+  }
+}
 
 const ApprovalRequestPage = async () => {
   const supabase = createServerClient(cookies())

--- a/src/app/(dashboard)/admin/approval-request/billing-statements/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/billing-statements/page.tsx
@@ -9,6 +9,7 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query'
+import { Metadata } from 'next'
 import dynamic from 'next/dynamic'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
@@ -20,6 +21,12 @@ const BillingStatementInfo = dynamic(
     ),
   { ssr: false },
 )
+
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Review Billing Statements',
+  }
+}
 
 const BillingStatementsApprovalRequestPage = async () => {
   const supabase = createServerClient(cookies())

--- a/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/page.tsx
@@ -10,6 +10,7 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query'
+import { Metadata } from 'next'
 import dynamic from 'next/dynamic'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
@@ -21,6 +22,12 @@ const PendingEmployeeInfo = dynamic(
     ),
   { ssr: false },
 )
+
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Review Employees',
+  }
+}
 
 const CompanyEmployeesApprovalRequestPage = async () => {
   const supabase = createServerClient(cookies())


### PR DESCRIPTION
### TL;DR
Added page titles to admin approval request pages

### What changed?
Added metadata exports to set page titles for:
- Review Accounts
- Review Billing Statements
- Review Employees

### How to test?
1. Navigate to each admin approval request page:
   - `/admin/approval-request/accounts`
   - `/admin/approval-request/billing-statements`
   - `/admin/approval-request/company-employees`
2. Verify that the browser tab displays the correct page title for each page

### Why make this change?
Improves user experience by providing clear page titles in browser tabs, making it easier for administrators to identify different approval request pages when multiple tabs are open