### PR TITLE
feat(navigation): close mobile sidebar on link click

### DIFF
--- a/src/components/layout/navigation/navigation-item.tsx
+++ b/src/components/layout/navigation/navigation-item.tsx
@@ -1,5 +1,9 @@
 'use client'
-import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ReactNode } from 'react'
@@ -14,6 +18,7 @@ const NavigationItem = ({
   icon?: ReactNode
 }) => {
   const pathName = usePathname()
+  const { setOpenMobile } = useSidebar()
 
   const isActive = pathName === href
 
@@ -23,6 +28,7 @@ const NavigationItem = ({
         <Link
           className="flex !h-11 flex-row items-center gap-4 px-4 py-2.5"
           href={href}
+          onClick={() => setOpenMobile(false)}
         >
           {Icon && Icon}
           <span className="text-[13px] font-medium">{title}</span>

--- a/src/components/layout/navigation/sub-navigation-item.tsx
+++ b/src/components/layout/navigation/sub-navigation-item.tsx
@@ -2,6 +2,7 @@
 import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from '@/components/ui/sidebar'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -17,6 +18,7 @@ const SubNavigationItem = ({
   icon?: ReactNode
 }) => {
   const pathName = usePathname()
+  const { setOpenMobile } = useSidebar()
 
   const isActive = pathName === href
 
@@ -26,6 +28,7 @@ const SubNavigationItem = ({
         <Link
           className="flex !h-11 flex-row items-center gap-4 px-4 py-2.5"
           href={href}
+          onClick={() => setOpenMobile(false)}
         >
           {Icon && Icon}
           <span className="text-[13px] font-medium">{title}</span>


### PR DESCRIPTION
### TL;DR
Added mobile sidebar auto-close functionality when navigating between pages

### What changed?
- Imported and implemented `useSidebar` hook in navigation components
- Added `onClick` handlers to navigation links that close the mobile sidebar when clicked
- Applied changes to both main navigation items and sub-navigation items

### How to test?
1. Open the application on a mobile device or using mobile device emulation
2. Open the mobile sidebar
3. Click on any navigation link
4. Verify that the sidebar automatically closes when navigating to a new page

### Why make this change?
Improves the mobile user experience by automatically closing the sidebar after navigation, preventing it from remaining open and obscuring the new page content