### PR TITLE
fix(admin): adjust approval request modal dimensions

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/accounts/approval-request-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/approval-request-info.tsx
@@ -25,7 +25,7 @@ const ApprovalRequestInfo = () => {
 
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-      <DialogContent className="max-w-6xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-x-2">
             Account Approval Request


### PR DESCRIPTION
### TL;DR
Added scrolling and adjusted width constraints for the account approval request modal

### What changed?
- Modified the dialog content's maximum width from `max-w-6xl` to `sm:max-w-4xl`
- Added `max-h-[90vh]` to limit the modal height to 90% of the viewport
- Implemented `overflow-y-auto` to enable vertical scrolling when content exceeds the height limit

### How to test?
1. Navigate to the admin approval request section
2. Open an account approval request modal
3. Verify that:
   - The modal is slightly narrower than before
   - Content scrolls vertically if it exceeds the viewport height
   - Modal height doesn't exceed 90% of the screen

### Why make this change?
To improve the user experience by ensuring the modal content remains accessible on smaller screens and preventing it from extending beyond comfortable viewing limits. The scrollable content area makes it easier to review longer approval requests while maintaining a consistent modal size.