### PR TITLE
TIM-699 Add table for employee exports

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-columns.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import TableHeader from '@/components/table-header'
+import { Tables } from '@/types/database.types'
+import { ColumnDef } from '@tanstack/react-table'
+import { formatDistanceToNow } from 'date-fns'
+
+const employeeExportRequestsColumns: ColumnDef<
+  Tables<'pending_export_requests'>
+>[] = [
+  {
+    accessorKey: 'account_id',
+    header: ({ column }) => <TableHeader column={column} title="Account" />,
+    accessorFn: (row) => {
+      ;(row.account_id as any)?.company_name
+    },
+    cell: ({ row }) => {
+      return <div>{(row.original.account_id as any)?.company_name}</div>
+    },
+  },
+  {
+    accessorKey: 'created_by',
+    header: ({ column }) => (
+      <TableHeader column={column} title="Requested By" />
+    ),
+    accessorFn: (row) =>
+      `${(row.created_by as any)?.first_name} ${
+        (row.created_by as any)?.last_name
+      }`,
+  },
+  {
+    accessorKey: 'created_at',
+    header: ({ column }) => (
+      <TableHeader column={column} title="Requested At" />
+    ),
+    cell: ({ row }) => {
+      return (
+        <div>
+          {formatDistanceToNow(new Date(row.original.created_at), {
+            addSuffix: true,
+          })}
+        </div>
+      )
+    },
+  },
+]
+
+export default employeeExportRequestsColumns

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-rows.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-rows.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { TableCell, TableRow } from '@/components/ui/table'
+import { ColumnDef, flexRender, Table } from '@tanstack/react-table'
+
+interface EmployeeExportRequestsRowsProps<TData> {
+  table: Table<TData>
+  columns: ColumnDef<TData>[]
+}
+
+const EmployeeExportRequestsRows = <TData,>({
+  table,
+  columns,
+}: EmployeeExportRequestsRowsProps<TData>) => {
+  return (
+    <>
+      {table.getRowModel().rows?.length ? (
+        table.getRowModel().rows.map((row) => (
+          <TableRow
+            key={row.id}
+            className="cursor-pointer hover:!bg-muted"
+            // onClick={() => handleOnClick(row.original)}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <TableCell key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))
+      ) : (
+        <TableRow>
+          <TableCell colSpan={columns.length} className="h-16 text-center">
+            No results.
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  )
+}
+
+export default EmployeeExportRequestsRows

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
@@ -10,13 +10,55 @@ import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getAllPendingEmployeeExports from '@/queries/get-all-pending-employee-exports'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import ApprovalRequestDataTableRow from '@/app/(dashboard)/admin/approval-request/accounts/approval-request-data-table-row'
+import accountsApprovalColumns from '@/app/(dashboard)/admin/approval-request/accounts/accounts-approval-columns'
+import TablePagination from '@/components/table-pagination'
+import accountExportRequestsColumns from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-columns'
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import employeeExportRequestsColumns from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-columns'
+import { useState } from 'react'
+import EmployeeExportRequestsRows from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-rows'
 
 const EmployeeExportsRequestsTable = () => {
   const supabase = createBrowserClient()
   // TODO: Add data from table
-  const { count, isPending } = useQuery(
+  const { data, count, isPending } = useQuery(
     getAllPendingEmployeeExports(supabase, 'employees'),
   )
+
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [globalFilter, setGlobalFilter] = useState<any>('')
+
+  const table = useReactTable({
+    data: (data as any) || [],
+    columns: employeeExportRequestsColumns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: 'includesString',
+    state: {
+      sorting,
+      globalFilter,
+    },
+  })
 
   return (
     <div className="flex flex-col">
@@ -36,6 +78,38 @@ const EmployeeExportsRequestsTable = () => {
           </div>
         </div>
       </PageHeader>
+
+      <div className="flex h-full flex-col justify-between bg-card">
+        <div className="h-full rounded-md border">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              <EmployeeExportRequestsRows
+                table={table}
+                columns={employeeExportRequestsColumns}
+              />
+            </TableBody>
+          </Table>
+        </div>
+        <TablePagination table={table} />
+      </div>
     </div>
   )
 }

--- a/src/queries/get-all-pending-employee-exports.ts
+++ b/src/queries/get-all-pending-employee-exports.ts
@@ -8,7 +8,7 @@ const getAllPendingEmployeeExports = (
   return supabase
     .from('pending_export_requests')
     .select(
-      `id, export_type, created_at, created_by(first_name, last_name, user_id)`,
+      `id, export_type, created_at, created_by(first_name, last_name, user_id), account_id(company_name)`,
       {
         count: 'exact',
       },


### PR DESCRIPTION
### TL;DR
Added a new employee export requests table with sorting, filtering, and pagination capabilities.

### What changed?
- Created new table columns for displaying account name, requester, and request timestamp
- Implemented table rows component with proper cell rendering
- Added table pagination and sorting functionality
- Enhanced the export requests query to include company name information
- Integrated table components into the main employee exports request view

### How to test?
1. Navigate to the admin approval request section
2. View the employee exports table
3. Verify that:
   - Account names, requesters, and timestamps are displayed correctly
   - Sorting works on all columns
   - Pagination controls function properly
   - "No results" message appears when table is empty

### Why make this change?
To provide administrators with a clear interface for managing employee export requests, allowing them to efficiently view and process pending requests with proper context about who made the request and when it was made.