### PR TITLE
fix(home): rerender error

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/client-acquisition/client-acquisition-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/client-acquisition/client-acquisition-chart.tsx
@@ -71,7 +71,9 @@ const ClientAcquisitionChart = () => {
     // force rerender to ensure chart updates
     setRerender(rerender + 1)
     return completeData
-  }, [data, rerender])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   return (
     <ChartContainer


### PR DESCRIPTION
### TL;DR
Fixed a React hooks dependency warning in the client acquisition chart component.

### What changed?
Removed `rerender` from the useEffect dependency array and added an ESLint disable comment to suppress the hooks exhaustive deps warning.

### How to test?
1. Navigate to the client acquisition chart
2. Verify the chart still updates correctly when data changes
3. Check browser console to confirm no React hooks dependency warnings

### Why make this change?
The `rerender` dependency was causing unnecessary re-renders and wasn't actually needed for the chart's functionality. This change improves performance while maintaining the same behavior.