### PR TITLE
TIM-722 Add sorting on query for accounts and utilized prefetchQuery

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-table.tsx
@@ -37,7 +37,7 @@ import TableSearch from '@/components/table-search'
 const AccountExportRequestsTable = () => {
   const supabase = createBrowserClient()
   const { data, count, isPending } = useQuery(
-    getPendingAccountExports(supabase, 'accounts'),
+    getPendingAccountExports(supabase, 'accounts', 'desc'),
   )
 
   const [sorting, setSorting] = useState<SortingState>([])

--- a/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
@@ -1,11 +1,26 @@
 import React from 'react'
 import AccountExportRequestsTable from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-table'
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import getPendingAccountExports from '@/queries/get-pending-account-exports'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
 
-const ExportRequestPage = () => {
+const ExportRequestPage = async () => {
+  const supabase = createServerClient(cookies())
+  const queryClient = new QueryClient()
+  await prefetchQuery(
+    queryClient,
+    getPendingAccountExports(supabase, 'accounts', 'desc'),
+  )
   return (
-    <div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <AccountExportRequestsTable />
-    </div>
+    </HydrationBoundary>
   )
 }
 

--- a/src/queries/get-pending-account-exports.ts
+++ b/src/queries/get-pending-account-exports.ts
@@ -4,6 +4,7 @@ import { Enums } from '@/types/database.types'
 const getPendingAccountExports = (
   supabase: TypedSupabaseClient,
   exportType: Enums<'export_type'>,
+  sort: 'asc' | 'desc' = 'desc',
 ) => {
   return supabase
     .from('pending_export_requests')
@@ -16,6 +17,7 @@ const getPendingAccountExports = (
     .eq('is_approved', false)
     .eq('is_active', true)
     .eq('export_type', exportType)
+    .order('created_at', { ascending: sort === 'asc' })
     .throwOnError()
 }
 


### PR DESCRIPTION
### TL;DR
Naintindihan ko na kung para san siya yehey

Added server-side prefetching and sorting functionality to account export requests.

### What changed?
- Implemented server-side data prefetching for account export requests using React Query
- Added sorting capability to pending account exports query with a default descending order
- Wrapped the account exports page with HydrationBoundary to prevent hydration issues
- Modified the query to support customizable sort direction (asc/desc)

### How to test?
1. Navigate to the account exports page
2. Verify that data loads immediately without loading states
3. Confirm that export requests are sorted by creation date in descending order
4. Check that the table maintains its state during page navigation

### Why make this change?
Server-side prefetching improves the initial page load experience by eliminating loading states and providing immediate data availability. The addition of sorting ensures a consistent and logical presentation of export requests, with the most recent requests appearing first by default.