### PR TITLE
TIM-725 Add sorting on query for employee exports and utilized ss prefetching

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
@@ -39,7 +39,7 @@ const EmployeeExportsRequestsTable = () => {
   const supabase = createBrowserClient()
   // TODO: Add data from table
   const { data, count, isPending } = useQuery(
-    getAllPendingEmployeeExports(supabase, 'employees'),
+    getAllPendingEmployeeExports(supabase, 'employees', 'desc'),
   )
 
   const [sorting, setSorting] = useState<SortingState>([])

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
@@ -1,11 +1,25 @@
 import React from 'react'
 import EmployeeExportsRequestsTable from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table'
+import { createBrowserClient } from '@/utils/supabase'
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import getAllPendingEmployeeExports from '@/queries/get-all-pending-employee-exports'
 
-const Page = () => {
+const Page = async () => {
+  const supabase = createBrowserClient()
+  const queryClient = new QueryClient()
+  await prefetchQuery(
+    queryClient,
+    getAllPendingEmployeeExports(supabase, 'employees', 'desc'),
+  )
   return (
-    <div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <EmployeeExportsRequestsTable />
-    </div>
+    </HydrationBoundary>
   )
 }
 

--- a/src/queries/get-all-pending-employee-exports.ts
+++ b/src/queries/get-all-pending-employee-exports.ts
@@ -4,6 +4,7 @@ import { Enums } from '@/types/database.types'
 const getAllPendingEmployeeExports = (
   supabase: TypedSupabaseClient,
   exportType: Enums<'export_type'>,
+  sort: 'asc' | 'desc' = 'desc',
 ) => {
   return supabase
     .from('pending_export_requests')
@@ -16,6 +17,7 @@ const getAllPendingEmployeeExports = (
     .eq('is_approved', false)
     .eq('is_active', true)
     .eq('export_type', exportType)
+    .order('created_at', { ascending: sort === 'asc' })
     .throwOnError()
 }
 


### PR DESCRIPTION
### TL;DR
Added sorting functionality to pending employee exports with default descending order by creation date.

### What changed?
- Added sorting parameter to `getAllPendingEmployeeExports` query
- Implemented default descending sort order by `created_at` field
- Added server-side prefetching for employee exports data
- Integrated React Query's hydration boundary for better data handling

### How to test?
1. Navigate to the employee exports approval request page
2. Verify that requests are sorted by creation date in descending order (newest first)
3. Confirm that the data is properly hydrated and displayed without loading flickers
4. Verify that the sorting functionality works correctly when changed

### Why make this change?
To improve user experience by displaying the most recent export requests first and implement proper server-side data fetching with hydration, reducing initial load times and preventing unnecessary client-side data fetching.