### PR TITLE
feat(accounts): remove resending of email

### DIFF
--- a/src/app/(auth)/confirm-account/set-password-form.tsx
+++ b/src/app/(auth)/confirm-account/set-password-form.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { createBrowserClient } from '@/utils/supabase'
 import Message from '@/components/message'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import setPasswordSchema from '@/app/(auth)/confirm-account/set-password-schema'
 
 const SetPasswordForm = () => {
@@ -64,6 +64,18 @@ const SetPasswordForm = () => {
     // if success, then redirect to home page
     router.push('/')
   }
+
+  // check if there is an error in the url
+  const params = new URLSearchParams(window.location.hash.slice())
+
+  if (params.get('error_code')?.startsWith('4')) {
+    // show error message if error is a 4xx error
+    return <Message variant="error">{params.get('error_description')}</Message>
+  }
+
+  // if (error_code && error_description) {
+  //   return <Message variant="error">{error_description}</Message>
+  // }
 
   return (
     <div className="flex flex-col gap-8 border-border pt-8 md:rounded-xl md:border md:bg-card md:p-12 md:shadow-sm">

--- a/src/app/(dashboard)/admin/users/edit/edit-user-form.tsx
+++ b/src/app/(dashboard)/admin/users/edit/edit-user-form.tsx
@@ -179,7 +179,7 @@ const EditUserForm: FC<Props> = ({
               </FormItem>
             )}
           />
-          <ConfirmEmail email={email} />
+          {/* <ConfirmEmail email={email} /> */}
         </div>
         <div className="fixed bottom-0 flex w-full flex-row items-center justify-between gap-2 bg-[#f1f5f9] px-4 py-3 md:max-w-2xl">
           <DeleteUser


### PR DESCRIPTION
### TL;DR
Added error handling for password confirmation page and temporarily disabled email confirmation in user edit form.

### What changed?
- Added URL parameter checking for error codes in the password confirmation page
- Implemented error message display for 4xx errors during password confirmation
- Commented out the `<ConfirmEmail>` component in the user edit form

### How to test?
1. Attempt to confirm a password with an invalid token/link
2. Verify that appropriate error messages are displayed for 4xx errors
3. Navigate to the user edit form and confirm that email confirmation option is not visible

### Why make this change?
To improve user experience by providing clear feedback when password confirmation fails and temporarily disable email confirmation functionality while updates are being made to the system.