### PR TITLE
feat(billing): prevent duplicate delete requests

### DIFF
--- a/src/components/billing-statement/delete-billing-statement.tsx
+++ b/src/components/billing-statement/delete-billing-statement.tsx
@@ -47,67 +47,93 @@ const DeleteBillingStatement = <TData,>({
   )
 
   const onDeleteHandler = async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
 
-    await mutateAsync([
-      {
-        mode_of_payment_id: originalData.mode_of_payment_id
-          ? originalData.mode_of_payment_id
-          : null,
-        due_date: originalData.due_date ? originalData.due_date : null,
-        or_number: originalData.or_number ? originalData.or_number : null,
-        or_date: originalData.or_date ? originalData.or_date : null,
-        sa_number: originalData.sa_number ? originalData.sa_number : null,
-        amount: originalData.amount ? originalData.amount : null,
-        total_contract_value: originalData.total_contract_value
-          ? originalData.total_contract_value
-          : null,
-        balance: originalData.balance ? originalData.balance : null,
-        billing_period: originalData.billing_period
-          ? originalData.billing_period
-          : null,
-        amount_billed: originalData.amount_billed
-          ? originalData.amount_billed
-          : null,
-        amount_paid: originalData.amount_paid ? originalData.amount_paid : null,
-        commission_rate: originalData.commission_rate
-          ? originalData.commission_rate
-          : null,
-        commission_earned: originalData.commission_earned
-          ? originalData.commission_earned
-          : null,
-        account_id: originalData.account_id ? originalData.account_id : null,
-        billing_statement_id: originalData.id ? originalData.id : null,
-        is_delete_billing_statement: true,
-        created_by: user?.id,
-        operation_type: 'delete',
-      },
-    ])
+      // check if a request is already pending
+      const { data: pendingRequest } = await supabase
+        .from('pending_billing_statements')
+        .select('billing_statement_id')
+        .eq('billing_statement_id', originalData.id)
+        .eq('created_by', user?.id)
+        .eq('operation_type', 'delete')
+        .eq('is_active', true)
+        .eq('is_approved', false)
+        .maybeSingle()
+
+      if (pendingRequest) {
+        // if pending request exists, then do not allow the user to create a new request
+        throw new Error(
+          'A request is already pending. Please wait for it to be processed.',
+        )
+      }
+
+      await mutateAsync([
+        {
+          mode_of_payment_id: originalData.mode_of_payment_id
+            ? originalData.mode_of_payment_id
+            : null,
+          due_date: originalData.due_date ? originalData.due_date : null,
+          or_number: originalData.or_number ? originalData.or_number : null,
+          or_date: originalData.or_date ? originalData.or_date : null,
+          sa_number: originalData.sa_number ? originalData.sa_number : null,
+          amount: originalData.amount ? originalData.amount : null,
+          total_contract_value: originalData.total_contract_value
+            ? originalData.total_contract_value
+            : null,
+          balance: originalData.balance ? originalData.balance : null,
+          billing_period: originalData.billing_period
+            ? originalData.billing_period
+            : null,
+          amount_billed: originalData.amount_billed
+            ? originalData.amount_billed
+            : null,
+          amount_paid: originalData.amount_paid
+            ? originalData.amount_paid
+            : null,
+          commission_rate: originalData.commission_rate
+            ? originalData.commission_rate
+            : null,
+          commission_earned: originalData.commission_earned
+            ? originalData.commission_earned
+            : null,
+          account_id: originalData.account_id ? originalData.account_id : null,
+          billing_statement_id: originalData.id ? originalData.id : null,
+          is_delete_billing_statement: true,
+          created_by: user?.id,
+          operation_type: 'delete',
+        },
+      ])
+    } catch (error: any) {
+      toast({
+        variant: 'destructive',
+        title: 'Something went wrong',
+        description: error.message,
+      })
+    }
   }
   return (
-    <>
-      <Button
-        variant={'destructive'}
-        type="button"
-        disabled={isPending}
-        onClick={() => {
-          openConfirmation({
-            title: 'Are you sure?',
-            description:
-              'This action CANNOT be undone. This will permanently delete the billing statement.',
-            cancelLabel: 'Cancel',
-            actionLabel: 'I understand, delete this billing statement',
-            confirmationButtonVariant: 'destructive',
-            onAction: () => onDeleteHandler(),
-            onCancel: () => {},
-          })
-        }}
-      >
-        <Trash />
-      </Button>
-    </>
+    <Button
+      variant={'destructive'}
+      type="button"
+      disabled={isPending}
+      onClick={() => {
+        openConfirmation({
+          title: 'Are you sure?',
+          description:
+            'This action CANNOT be undone. This will permanently delete the billing statement.',
+          cancelLabel: 'Cancel',
+          actionLabel: 'I understand, delete this billing statement',
+          confirmationButtonVariant: 'destructive',
+          onAction: () => onDeleteHandler(),
+          onCancel: () => {},
+        })
+      }}
+    >
+      <Trash />
+    </Button>
   )
 }
 


### PR DESCRIPTION
### TL;DR
Added validation to prevent duplicate delete requests for billing statements

### What changed?
- Added a check to verify if a pending delete request already exists for a billing statement
- Implemented error handling with toast notifications for duplicate requests
- Wrapped the delete operation in a try-catch block for better error management
- Removed unnecessary fragment wrapper around the delete button

### How to test?
1. Navigate to a billing statement
2. Click the delete button
3. Verify that you cannot submit multiple delete requests for the same billing statement
4. Confirm that an error toast appears when attempting to create duplicate requests
5. Verify that the delete operation still works when there are no pending requests

### Why make this change?
To prevent duplicate delete requests from being created for the same billing statement, which could lead to data inconsistency and confusion in the approval process. This change improves data integrity and user feedback.