### PR TITLE
feat(employees): add RLS policy for pending updates

### DIFF
--- a/supabase/migrations/20241111123922_rls_update_on_employees.sql
+++ b/supabase/migrations/20241111123922_rls_update_on_employees.sql
@@ -1,0 +1,13 @@
+create policy "Enable update for users based on created_by"
+on "public"."pending_company_employees"
+as permissive
+for update
+to authenticated
+using (((( SELECT auth.uid() AS uid) = created_by) AND (is_approved = false) AND (EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'marketing'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text])))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Added RLS policy to control employee updates based on user permissions and department roles.

### What changed?
Created a new Row Level Security (RLS) policy for the `pending_company_employees` table that allows updates only when:
- The authenticated user is the creator of the record
- The employee record is not yet approved
- The user belongs to specific departments (admin, marketing, finance, after-sales, or under-writing)

### How to test?
1. Log in as a user from one of the allowed departments
2. Attempt to update a pending employee record you created
3. Verify update succeeds
4. Try updating an approved record or one created by another user
5. Verify update fails
6. Test with a user from an unauthorized department
7. Verify update fails

### Why make this change?
To implement proper access control ensuring only authorized personnel from specific departments can modify pending employee records they created, enhancing data security and maintaining proper organizational hierarchy.