### PR TITLE
refactor(employees): simplify date parsing logic

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/parseDate.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/parseDate.ts
@@ -1,17 +1,11 @@
-import { format } from 'date-fns'
+import { format, isValid } from 'date-fns'
 import { RawData } from 'react-spreadsheet-import/types/types'
 
 const parseDate = (data: RawData[]): Promise<RawData[]> => {
   return new Promise((resolve) => {
     const formattedData = data.map((row) => {
       return row.map((cell) => {
-        if (
-          typeof cell === 'string' &&
-          !/\d{1,2}\/\d{1,2}\/\d{4} to \d{1,2}\/\d{1,2}\/\d{4}/.test(cell) &&
-          (/\d{1,2}\/\d{1,2}\/\d{4}/.test(cell) ||
-            /\d{1,2} \w{3} \d{4}/.test(cell) ||
-            /\d{1}\/\d{2}\/\d{4}/.test(cell))
-        ) {
+        if (typeof cell === 'string' && isValid(cell)) {
           return format(new Date(cell), 'MM/dd/yyyy')
         }
         return cell


### PR DESCRIPTION
### TL;DR
Simplified date parsing logic using `isValid` from date-fns library

### What changed?
Replaced complex regex date validation with `isValid` function from date-fns to determine if a string can be parsed as a valid date

### How to test?
1. Import data with various date formats (MM/dd/yyyy, dd MMM yyyy, M/dd/yyyy)
2. Verify dates are correctly parsed and formatted to MM/dd/yyyy
3. Ensure invalid date strings remain unchanged

### Why make this change?
The previous regex-based validation was overly complex and potentially brittle. Using `isValid` from date-fns provides a more reliable and maintainable way to validate dates while handling a wider range of valid date formats.