### PR TITLE
TIM-630 Confirmation modal for account exports table

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
@@ -1,0 +1,50 @@
+'use client'
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
+import { formatDate } from 'date-fns'
+
+const AccountExportRequestModal = () => {
+  const { isModalOpen, setIsModalOpen, selectedData } =
+    useAccountExportRequestsContext()
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Confirm Action</DialogTitle>
+          <DialogDescription>
+            Please choose whether to approve or reject this export request.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="text-base">
+          Would you like to approve this export request created by
+          <span className="font-bold">
+            {' '}
+            {(selectedData?.created_by as any)?.first_name}{' '}
+            {(selectedData?.created_by as any)?.last_name}{' '}
+          </span>{' '}
+          on
+          <span className="font-bold">
+            {' '}
+            {selectedData?.created_at
+              ? formatDate(selectedData.created_at, 'PP')
+              : '-'}{' '}
+          </span>
+          ?
+        </div>
+        <div className="flex justify-end gap-x-2">
+          {/* TODO: Buttons for reject and approved*/}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AccountExportRequestModal

--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-columns.tsx
@@ -3,6 +3,8 @@ import { Tables } from '@/types/database.types'
 import TableHeader from '@/components/table-header'
 import { ColumnDef } from '@tanstack/react-table'
 import { formatDistanceToNow } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { MoreHorizontal } from 'lucide-react'
 
 const accountExportRequestsColumns: ColumnDef<
   Tables<'pending_export_requests'>
@@ -29,6 +31,16 @@ const accountExportRequestsColumns: ColumnDef<
             addSuffix: true,
           })}
         </div>
+      )
+    },
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      return (
+        <Button size={'icon'} variant="ghost">
+          <MoreHorizontal className="cursor-pointer" />
+        </Button>
       )
     },
   },

--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { createContext, ReactNode, useContext, useState } from 'react'
+import { Tables } from '@/types/database.types'
+
+const useAccountExportRequestsContext = () => {
+  const context = useContext(AccountExportRequestsContext)
+  if (!context) {
+    throw new Error(
+      'useAccountExportRequestsContext must be used within a AccountExportRequestsProvider',
+    )
+  }
+  return context
+}
+
+const AccountExportRequestsContext = createContext({
+  isModalOpen: false,
+  setIsModalOpen: (_value: boolean) => {},
+  isLoading: false,
+  setIsLoading: (_value: boolean) => {},
+  selectedData: undefined as Tables<'pending_export_requests'> | undefined,
+  setSelectedData: (_value: any) => {},
+})
+
+const AccountExportRequestsProvider = ({
+  children,
+}: {
+  children: ReactNode
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [selectedData, setSelectedData] = useState<any | undefined>(undefined)
+  return (
+    <AccountExportRequestsContext.Provider
+      value={{
+        isModalOpen,
+        setIsModalOpen,
+        isLoading,
+        setIsLoading,
+        selectedData,
+        setSelectedData,
+      }}
+    >
+      {children}
+    </AccountExportRequestsContext.Provider>
+  )
+}
+
+export { AccountExportRequestsProvider, useAccountExportRequestsContext }

--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-rows.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-rows.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { TableCell, TableRow } from '@/components/ui/table'
 import { ColumnDef, flexRender, Table } from '@tanstack/react-table'
+import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
 
 interface AccountExportRequestsRowsProps<TData> {
   table: Table<TData>
@@ -11,6 +12,12 @@ const AccountExportRequestsRows = <TData,>({
   table,
   columns,
 }: AccountExportRequestsRowsProps<TData>) => {
+  const { setIsModalOpen, setSelectedData } = useAccountExportRequestsContext()
+
+  const handleOnClick = (originalData: TData) => {
+    setIsModalOpen(true)
+    setSelectedData(originalData)
+  }
   return (
     <>
       {table.getRowModel().rows?.length ? (
@@ -18,7 +25,7 @@ const AccountExportRequestsRows = <TData,>({
           <TableRow
             key={row.id}
             className="cursor-pointer hover:!bg-muted"
-            // onClick={() => handleOnClick(row.original)}
+            onClick={() => handleOnClick(row.original)}
           >
             {row.getVisibleCells().map((cell) => (
               <TableCell key={cell.id}>

--- a/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
@@ -9,6 +9,8 @@ import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getPendingAccountExports from '@/queries/get-pending-account-exports'
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
+import AccountExportRequestModal from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal'
+import { AccountExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
 
 const ExportRequestPage = async () => {
   const supabase = createServerClient(cookies())
@@ -19,7 +21,10 @@ const ExportRequestPage = async () => {
   )
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <AccountExportRequestsTable />
+      <AccountExportRequestsProvider>
+        <AccountExportRequestsTable />
+        <AccountExportRequestModal />
+      </AccountExportRequestsProvider>
     </HydrationBoundary>
   )
 }


### PR DESCRIPTION
### TL;DR
I used a context provider 
![baby-cute.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vJGCtZypD2dCSpqs2VMi/cf370a8d-0fce-44d5-98de-4a6acdc95bc6.gif)
Added a modal dialog for handling account export request approvals with context management.

### What changed?
- Created a new modal component for displaying account export request details
- Implemented a context provider to manage the modal state and selected request data
- Added an actions column with a menu button to the export requests table
- Enhanced table rows with click handling to open the modal
- Connected the modal to display the requester's name and creation date

### How to test?
1. Navigate to the admin approval request page
2. Click on any row in the account export requests table
3. Verify that the modal opens with the correct user details and creation date
4. Confirm that the modal can be closed
5. Check that the menu button appears in the actions column

### Why make this change?
To provide administrators with a clear interface for reviewing and managing account export requests, ensuring proper validation and confirmation before approving or rejecting requests.

