### PR TITLE
fix(admin): correct birth date display in batch employee view

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/information/batch-employee.tsx
@@ -23,7 +23,7 @@ const BatchEmployee = () => {
           <ApprovalInformationItem
             label="Birth Date"
             value={
-              (selectedData as any)?.birth_date
+              (item as any)?.birth_date
                 ? formatDate((item as any).birth_date, 'PP')
                 : undefined
             }


### PR DESCRIPTION
### TL;DR
Fixed birth date display in batch employee approval view

### What changed?
Updated the birth date field to correctly reference individual employee data instead of the parent selected data object

### How to test?
1. Navigate to the admin approval request page
2. Select a batch of employees for approval
3. Verify that each employee's birth date is displayed correctly in their respective information sections

### Why make this change?
The birth date was previously referencing the parent selectedData object instead of the individual employee item, causing incorrect or missing birth date displays in the batch approval view. This fix ensures each employee's correct birth date is shown.