### PR TITLE
refactor(table): remove column visibility toggle

### DIFF
--- a/src/components/table-header.tsx
+++ b/src/components/table-header.tsx
@@ -2,19 +2,17 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CaretSortIcon,
-  EyeNoneIcon,
 } from '@radix-ui/react-icons'
 import { Column } from '@tanstack/react-table'
 
+import { cn } from '@/utils/tailwind'
+import { Button } from './ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu'
-import { Button } from './ui/button'
-import { cn } from '@/utils/tailwind'
 
 interface DataTableColumnHeaderProps<TData, TValue>
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -58,11 +56,6 @@ const TableHeader = <TData, TValue>({
           <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
             <ArrowDownIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
             Desc
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
-            <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Hide
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
### TL;DR
Removed column hiding functionality from table headers and simplified the dropdown menu

### What changed?
- Removed the "Hide" option from column header dropdown menus
- Removed `EyeNoneIcon` import and related components
- Removed dropdown menu separator
- Reordered imports for better organization

### How to test?
1. Open any table with sortable columns
2. Click the dropdown menu in any column header
3. Verify only "Asc" and "Desc" sorting options are present
4. Confirm the column hiding functionality is no longer available

### Why make this change?
The column hiding functionality was determined to be unnecessary for the current use case, leading to a cleaner and more focused user interface. This simplification makes the table header interactions more straightforward and reduces potential user confusion.