### PR TITLE
fix(admin): update approval request toast messages

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/company-employees/employee-action-button.tsx
@@ -47,8 +47,8 @@ const EmployeeActionButton: FC<EmployeeActionButtonProps> = ({
     {
       onSuccess: () => {
         toast({
-          title: 'Success',
-          description: 'The request has been approved successfully',
+          title: `Request ${action === 'approve' ? 'approved' : 'rejected'}`,
+          description: `The request has been ${action === 'approve' ? 'approved' : 'rejected'} successfully`,
         })
         setIsModalOpen(false)
       },


### PR DESCRIPTION
### TL;DR
Updated success toast messages for employee approval/rejection actions to be more specific.

### What changed?
Modified the success toast notifications to dynamically display whether the request was approved or rejected, rather than using generic "Success" messaging.

### How to test?
1. Navigate to the admin approval request page
2. Attempt to approve or reject an employee request
3. Verify the toast message displays the correct action (approved/rejected)
4. Confirm the toast description matches the action taken

### Why make this change?
To provide clearer feedback to administrators when they take action on employee requests, making it immediately obvious which action was successfully completed.