### PR TITLE
TIM-728 Add a context provider for employee exports table

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { createContext, ReactNode, useContext, useState } from 'react'
+import { Tables } from '@/types/database.types'
+
+const useEmployeeExportRequestsContext = () => {
+  const context = useContext(EmployeeExportRequestsContext)
+  if (!context) {
+    throw new Error(
+      'useEmployeeExportRequestsContext must be used within a EmployeeExportRequestsProvider',
+    )
+  }
+  return context
+}
+
+const EmployeeExportRequestsContext = createContext({
+  isModalOpen: false,
+  setIsModalOpen: (_value: boolean) => {},
+  isLoading: false,
+  setIsLoading: (_value: boolean) => {},
+  selectedData: undefined as Tables<'pending_export_requests'> | undefined,
+  setSelectedData: (_value: any) => {},
+})
+
+const EmployeeExportRequestsProvider = ({
+  children,
+}: {
+  children: ReactNode
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [selectedData, setSelectedData] = useState<any | undefined>(undefined)
+
+  return (
+    <EmployeeExportRequestsContext.Provider
+      value={{
+        isModalOpen,
+        setIsModalOpen,
+        isLoading,
+        setIsLoading,
+        selectedData,
+        setSelectedData,
+      }}
+    >
+      {children}
+    </EmployeeExportRequestsContext.Provider>
+  )
+}
+
+export { EmployeeExportRequestsProvider, useEmployeeExportRequestsContext }


### PR DESCRIPTION
### TL;DR
Please check if im doing things right

Added a new context provider for managing employee export request states.

### What changed?
Created `EmployeeExportRequestsProvider` and its corresponding hook to manage modal state, loading state, and selected data for employee export requests. The provider exposes methods to control these states and makes them available throughout the component tree.

### How to test?
1. Import and wrap components that need access to employee export request states with `EmployeeExportRequestsProvider`
2. Use `useEmployeeExportRequestsContext` hook in child components
3. Verify that modal, loading states, and selected data can be accessed and modified
4. Ensure context throws an error when used outside of provider

### Why make this change?
To centralize the state management for employee export requests and provide a consistent way to handle modal interactions, loading states, and selected data across multiple components in the admin approval request flow.