### PR TITLE
TIM-727 feat: Confirmation modal for company employees

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-columns.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-columns.tsx
@@ -3,6 +3,8 @@ import TableHeader from '@/components/table-header'
 import { Tables } from '@/types/database.types'
 import { ColumnDef } from '@tanstack/react-table'
 import { formatDistanceToNow } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import { MoreHorizontal } from 'lucide-react'
 
 const employeeExportRequestsColumns: ColumnDef<
   Tables<'pending_export_requests'>
@@ -39,6 +41,16 @@ const employeeExportRequestsColumns: ColumnDef<
             addSuffix: true,
           })}
         </div>
+      )
+    },
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      return (
+        <Button size={'icon'} variant="ghost">
+          <MoreHorizontal className="cursor-pointer" />
+        </Button>
       )
     },
   },

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal.tsx
@@ -1,0 +1,50 @@
+'use client'
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useEmployeeExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
+import { formatDate } from 'date-fns'
+
+const EmployeeExportRequestsModal = () => {
+  const { isModalOpen, setIsModalOpen, selectedData } =
+    useEmployeeExportRequestsContext()
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Confirm Action</DialogTitle>
+          <DialogDescription>
+            Please choose whether to approve or reject this export request.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="text-base">
+          Would you like to approve this export request created by
+          <span className="font-bold">
+            {' '}
+            {(selectedData?.created_by as any)?.first_name}{' '}
+            {(selectedData?.created_by as any)?.last_name}{' '}
+          </span>{' '}
+          on
+          <span className="font-bold">
+            {' '}
+            {selectedData?.created_at
+              ? formatDate(selectedData.created_at, 'PP')
+              : '-'}{' '}
+          </span>
+          ?
+        </div>
+        <div className="flex justify-end gap-x-2">
+          {/* TODO: Buttons for reject and approved*/}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default EmployeeExportRequestsModal

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-rows.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-rows.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { TableCell, TableRow } from '@/components/ui/table'
 import { ColumnDef, flexRender, Table } from '@tanstack/react-table'
+import { useEmployeeExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
 
 interface EmployeeExportRequestsRowsProps<TData> {
   table: Table<TData>
@@ -11,6 +12,12 @@ const EmployeeExportRequestsRows = <TData,>({
   table,
   columns,
 }: EmployeeExportRequestsRowsProps<TData>) => {
+  const { setIsModalOpen, setSelectedData } = useEmployeeExportRequestsContext()
+
+  const handleOnClick = (originalData: TData) => {
+    setIsModalOpen(true)
+    setSelectedData(originalData)
+  }
   return (
     <>
       {table.getRowModel().rows?.length ? (
@@ -18,7 +25,7 @@ const EmployeeExportRequestsRows = <TData,>({
           <TableRow
             key={row.id}
             className="cursor-pointer hover:!bg-muted"
-            // onClick={() => handleOnClick(row.original)}
+            onClick={() => handleOnClick(row.original)}
           >
             {row.getVisibleCells().map((cell) => (
               <TableCell key={cell.id}>

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table.tsx
@@ -37,7 +37,6 @@ import TableSearch from '@/components/table-search'
 
 const EmployeeExportsRequestsTable = () => {
   const supabase = createBrowserClient()
-  // TODO: Add data from table
   const { data, count, isPending } = useQuery(
     getAllPendingEmployeeExports(supabase, 'employees', 'desc'),
   )

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import EmployeeExportsRequestsTable from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table'
-import { createBrowserClient } from '@/utils/supabase'
+import { createServerClient } from '@/utils/supabase'
 import {
   dehydrate,
   HydrationBoundary,
@@ -8,9 +8,12 @@ import {
 } from '@tanstack/react-query'
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import getAllPendingEmployeeExports from '@/queries/get-all-pending-employee-exports'
+import { cookies } from 'next/headers'
+import EmployeeExportRequestsModal from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal'
+import { EmployeeExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
 
 const Page = async () => {
-  const supabase = createBrowserClient()
+  const supabase = createServerClient(cookies())
   const queryClient = new QueryClient()
   await prefetchQuery(
     queryClient,
@@ -18,7 +21,10 @@ const Page = async () => {
   )
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <EmployeeExportsRequestsTable />
+      <EmployeeExportRequestsProvider>
+        <EmployeeExportsRequestsTable />
+        <EmployeeExportRequestsModal />
+      </EmployeeExportRequestsProvider>
     </HydrationBoundary>
   )
 }


### PR DESCRIPTION
### TL;DR
Added a modal dialog for handling employee export request approvals and rejections.

### What changed?
- Added an actions column with a menu button to the employee export requests table
- Created a new modal component to display export request details
- Implemented context provider for managing modal state and selected data
- Connected row click handlers to open the modal with request information
- Switched from browser to server client for initial data fetching

### How to test?
1. Navigate to the employee export requests page
2. Click on any row in the table or the menu button
3. Verify that the modal opens with the correct request details
4. Confirm that the requester's name and creation date are displayed properly
5. Verify that the modal can be closed

### Why make this change?
To provide administrators with a clear interface for reviewing and taking action on employee export requests. The modal implementation improves the user experience by displaying relevant request details and will eventually include approval/rejection functionality.