### PR TITLE
refactor(retention): improve rate calculation accuracy

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
@@ -9,14 +9,14 @@ import {
 import { format, subMonths } from 'date-fns'
 
 const RetentionRateCard = () => {
-  const last12Months = subMonths(new Date(), 12)
+  const lastMonth = subMonths(new Date(), 1)
 
   return (
     <Card className="col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">Retention Rate</CardTitle>
         <CardDescription className="text-xs font-medium">
-          From {format(last12Months, 'MMM yyyy')} to{' '}
+          From {format(lastMonth, 'MMM yyyy')} to{' '}
           {format(new Date(), 'MMM yyyy')}
         </CardDescription>
       </CardHeader>

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -34,6 +34,35 @@ export type Database = {
   }
   public: {
     Tables: {
+      account_status_changes: {
+        Row: {
+          account_id: string
+          changed_at: string
+          id: string
+          is_account_active: boolean
+        }
+        Insert: {
+          account_id: string
+          changed_at?: string
+          id?: string
+          is_account_active: boolean
+        }
+        Update: {
+          account_id?: string
+          changed_at?: string
+          id?: string
+          is_account_active?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'account_status_changes_account_id_fkey'
+            columns: ['account_id']
+            isOneToOne: false
+            referencedRelation: 'accounts'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       account_types: {
         Row: {
           created_at: string | null

--- a/src/utils/retentionRate.ts
+++ b/src/utils/retentionRate.ts
@@ -1,0 +1,68 @@
+// Define the type for the data
+interface AccountStatusChange {
+  account_id: string
+  is_account_active: boolean
+  changed_at: string
+}
+
+export function calculateRetentionRate(
+  data: AccountStatusChange[],
+  periodStart: Date,
+  periodEnd: Date,
+): number {
+  if (!data) {
+    return 0
+  }
+
+  // Get the latest status change before the periodStart for each account
+  const latestStatusBeforePeriodStart = data.reduce<
+    Record<string, AccountStatusChange>
+  >((acc, change) => {
+    if (
+      new Date(change.changed_at) <= periodStart &&
+      (!acc[change.account_id] ||
+        new Date(acc[change.account_id].changed_at) <
+          new Date(change.changed_at))
+    ) {
+      acc[change.account_id] = change
+    }
+    return acc
+  }, {})
+
+  // Clients who were active at the start of the period
+  const activeClientsAtStart = Object.values(
+    latestStatusBeforePeriodStart,
+  ).filter((change) => change.is_account_active).length
+
+  // Get the latest status change up to the periodEnd for each account
+  const latestStatusUpToPeriodEnd = data.reduce<
+    Record<string, AccountStatusChange>
+  >((acc, change) => {
+    if (
+      new Date(change.changed_at) <= periodEnd &&
+      (!acc[change.account_id] ||
+        new Date(acc[change.account_id].changed_at) <
+          new Date(change.changed_at))
+    ) {
+      acc[change.account_id] = change
+    }
+    return acc
+  }, {})
+
+  // Clients who were active at the start and remained active at the end of the period
+  const retainedClients = Object.keys(latestStatusBeforePeriodStart).filter(
+    (accountId) => {
+      const startStatus = latestStatusBeforePeriodStart[accountId]
+      const endStatus = latestStatusUpToPeriodEnd[accountId]
+      return startStatus?.is_account_active && endStatus?.is_account_active
+    },
+  ).length
+
+  // Retention Rate Calculation
+  const retentionRate =
+    activeClientsAtStart > 0
+      ? (retainedClients / activeClientsAtStart) * 100
+      : 0 // Handle division by zero
+
+  return Math.round(retentionRate) // Returns as a rounded number
+}

--- a/supabase/migrations/20241112121323_add_account_status_changes_table.sql
+++ b/supabase/migrations/20241112121323_add_account_status_changes_table.sql
@@ -1,0 +1,92 @@
+create extension if not exists "hypopg" with schema "extensions";
+
+create extension if not exists "index_advisor" with schema "extensions";
+
+
+create table "public"."account_status_changes" (
+    "id" uuid not null default gen_random_uuid(),
+    "account_id" uuid not null,
+    "is_account_active" boolean not null,
+    "changed_at" timestamp with time zone not null default now()
+);
+
+
+alter table "public"."account_status_changes" enable row level security;
+
+CREATE UNIQUE INDEX account_status_changes_pkey ON public.account_status_changes USING btree (id);
+
+alter table "public"."account_status_changes" add constraint "account_status_changes_pkey" PRIMARY KEY using index "account_status_changes_pkey";
+
+alter table "public"."account_status_changes" add constraint "account_status_changes_account_id_fkey" FOREIGN KEY (account_id) REFERENCES accounts(id) not valid;
+
+alter table "public"."account_status_changes" validate constraint "account_status_changes_account_id_fkey";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.log_account_status_change()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$BEGIN
+  INSERT INTO account_status_changes (account_id, is_account_active, changed_at)
+  VALUES (NEW.id, NEW.is_account_active, CURRENT_TIMESTAMP);
+  RETURN NEW;
+END;$function$
+;
+
+grant delete on table "public"."account_status_changes" to "anon";
+
+grant insert on table "public"."account_status_changes" to "anon";
+
+grant references on table "public"."account_status_changes" to "anon";
+
+grant select on table "public"."account_status_changes" to "anon";
+
+grant trigger on table "public"."account_status_changes" to "anon";
+
+grant truncate on table "public"."account_status_changes" to "anon";
+
+grant update on table "public"."account_status_changes" to "anon";
+
+grant delete on table "public"."account_status_changes" to "authenticated";
+
+grant insert on table "public"."account_status_changes" to "authenticated";
+
+grant references on table "public"."account_status_changes" to "authenticated";
+
+grant select on table "public"."account_status_changes" to "authenticated";
+
+grant trigger on table "public"."account_status_changes" to "authenticated";
+
+grant truncate on table "public"."account_status_changes" to "authenticated";
+
+grant update on table "public"."account_status_changes" to "authenticated";
+
+grant delete on table "public"."account_status_changes" to "service_role";
+
+grant insert on table "public"."account_status_changes" to "service_role";
+
+grant references on table "public"."account_status_changes" to "service_role";
+
+grant select on table "public"."account_status_changes" to "service_role";
+
+grant trigger on table "public"."account_status_changes" to "service_role";
+
+grant truncate on table "public"."account_status_changes" to "service_role";
+
+grant update on table "public"."account_status_changes" to "service_role";
+
+create policy "Enable all access for admin"
+on "public"."account_status_changes"
+as permissive
+for all
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = 'admin'::text)))))));
+
+
+CREATE TRIGGER account_status_change_trigger AFTER INSERT OR UPDATE ON public.accounts FOR EACH ROW EXECUTE FUNCTION log_account_status_change();
+
+

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -186,7 +186,7 @@ BEGIN
             'Signatory ' || i,
             'Designation ' || i,
             'contact' || i || '@example.com',
-            timestamp '2022-01-01 00:00:00' + random() * (timestamp '2024-12-31 23:59:59' - timestamp '2022-01-01 00:00:00')
+            timestamp '2022-10-01' + random() * (timestamp '2024-10-01' - timestamp '2022-10-01')
         );
     END LOOP;
 END $$;
@@ -284,3 +284,20 @@ BEGIN
     END LOOP;
 END $$;
 
+
+DO $$
+DECLARE
+    account RECORD;
+BEGIN
+    FOR account IN SELECT id, created_at, is_active FROM accounts LOOP
+        INSERT INTO public.account_status_changes (
+            account_id,
+            is_account_active,
+            changed_at
+        ) VALUES (
+            account.id,
+            account.is_active, -- Use the is_active status from the accounts table
+            account.created_at -- Use the created_at date from the accounts table
+        );
+    END LOOP;
+END $$;


### PR DESCRIPTION
### TL;DR
Improved retention rate calculation accuracy by tracking account status changes over time.

### What changed?
- Created new `account_status_changes` table to track historical account status
- Added database trigger to log status changes automatically
- Implemented `calculateRetentionRate` utility function for precise calculations
- Updated retention rate display period from 12 months to 1 month
- Modified seed data to populate historical status changes

### How to test?
1. Run database migrations to create the new table and trigger
2. Execute seed data to populate historical account changes
3. Verify retention rate calculation in dashboard
4. Toggle account status and confirm changes are logged
5. Check that retention rate updates accordingly

### Why make this change?
The previous implementation only considered current account status, which didn't accurately reflect retention over time. This new approach tracks all status changes, providing a more accurate measurement of customer retention by considering the actual state of accounts at both the start and end of the measurement period.