### PR TITLE
TIM-729 Add approval buttons to account export request modal

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
@@ -9,9 +9,14 @@ import {
 } from '@/components/ui/dialog'
 import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
 import { formatDate } from 'date-fns'
+import ActionRequestButton from '@/app/(dashboard)/admin/approval-request/accounts/action-request-button'
+import { Button } from '@/components/ui/button'
+import AccountExportRequestsApprovalButton from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-approval-button'
+import { Loader2 } from 'lucide-react'
+import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
 
 const AccountExportRequestModal = () => {
-  const { isModalOpen, setIsModalOpen, selectedData } =
+  const { isModalOpen, setIsModalOpen, selectedData, isLoading } =
     useAccountExportRequestsContext()
 
   return (
@@ -40,7 +45,22 @@ const AccountExportRequestModal = () => {
           ?
         </div>
         <div className="flex justify-end gap-x-2">
-          {/* TODO: Buttons for reject and approved*/}
+          <AccountExportRequestsApprovalButton
+            action="reject"
+            exportId={selectedData?.id as any}
+          >
+            <Button variant={'destructive'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Reject'}
+            </Button>
+          </AccountExportRequestsApprovalButton>
+          <AccountExportRequestsApprovalButton
+            action="approve"
+            exportId={selectedData?.id as any}
+          >
+            <Button variant={'default'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Approve'}
+            </Button>
+          </AccountExportRequestsApprovalButton>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-approval-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-approval-button.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { FC, ReactNode } from 'react'
+import { createBrowserClient } from '@/utils/supabase'
+import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { toast } from '@/components/ui/use-toast'
+import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
+
+interface AccountExportRequestsApprovalButtonProps {
+  children: ReactNode
+  action: 'approve' | 'reject'
+  exportId: string
+}
+
+const AccountExportRequestsApprovalButton: FC<
+  AccountExportRequestsApprovalButtonProps
+> = ({ children, action, exportId }) => {
+  const supabase = createBrowserClient()
+  const { setIsModalOpen } = useAccountExportRequestsContext()
+
+  const { mutateAsync, isPending } = useUpdateMutation(
+    //@ts-expect-error
+    supabase.from('pending_export_requests'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        toast({
+          title: `Request ${action === 'approve' ? 'approved' : 'rejected'}`,
+          description: `The request has been ${action === 'approve' ? 'approved' : 'rejected'} successfully`,
+        })
+        setIsModalOpen(false)
+      },
+      onError: () => {
+        toast({
+          title: 'Error',
+          description: 'An error occurred while approving the request',
+        })
+      },
+    },
+  )
+
+  const handleApproval = async () => {
+    if (action === 'approve') {
+      await mutateAsync({ id: exportId, is_approved: true })
+    } else {
+      await mutateAsync({ id: exportId, is_approved: false, is_active: false })
+    }
+  }
+
+  return <div onClick={handleApproval}> {children} </div>
+}
+
+export default AccountExportRequestsApprovalButton


### PR DESCRIPTION
### TL;DR
Added approval and rejection functionality to the Account Export Request Modal

### What changed?
- Added approve and reject buttons to the Account Export Request Modal
- Created a new `AccountExportRequestsApprovalButton` component to handle approval/rejection logic
- Integrated loading states and success/error toasts for user feedback
- Connected the approval actions to the Supabase database

### How to test?
1. Navigate to the admin approval requests section
2. Open an account export request modal
3. Test the approve button:
   - Click approve
   - Verify success toast appears
   - Confirm request status updates in database
4. Test the reject button:
   - Click reject
   - Verify success toast appears
   - Confirm request is marked as rejected and inactive

### Why make this change?
To provide administrators with the ability to approve or reject account export requests directly from the modal interface, streamlining the approval workflow process.