### PR TITLE
TIM-730 Refactor export request approval buttons and add to employee exports

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal.tsx
@@ -9,11 +9,9 @@ import {
 } from '@/components/ui/dialog'
 import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
 import { formatDate } from 'date-fns'
-import ActionRequestButton from '@/app/(dashboard)/admin/approval-request/accounts/action-request-button'
 import { Button } from '@/components/ui/button'
-import AccountExportRequestsApprovalButton from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-approval-button'
+import ExportRequestsApprovalButton from '@/app/(dashboard)/admin/approval-request/components/export-requests-approval-button'
 import { Loader2 } from 'lucide-react'
-import { useCompanyContext } from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
 
 const AccountExportRequestModal = () => {
   const { isModalOpen, setIsModalOpen, selectedData, isLoading } =
@@ -45,22 +43,22 @@ const AccountExportRequestModal = () => {
           ?
         </div>
         <div className="flex justify-end gap-x-2">
-          <AccountExportRequestsApprovalButton
+          <ExportRequestsApprovalButton
             action="reject"
             exportId={selectedData?.id as any}
           >
             <Button variant={'destructive'} disabled={isLoading}>
               {isLoading ? <Loader2 className="animate-spin" /> : 'Reject'}
             </Button>
-          </AccountExportRequestsApprovalButton>
-          <AccountExportRequestsApprovalButton
+          </ExportRequestsApprovalButton>
+          <ExportRequestsApprovalButton
             action="approve"
             exportId={selectedData?.id as any}
           >
             <Button variant={'default'} disabled={isLoading}>
               {isLoading ? <Loader2 className="animate-spin" /> : 'Approve'}
             </Button>
-          </AccountExportRequestsApprovalButton>
+          </ExportRequestsApprovalButton>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/(dashboard)/admin/approval-request/components/export-requests-approval-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/components/export-requests-approval-button.tsx
@@ -4,6 +4,7 @@ import { createBrowserClient } from '@/utils/supabase'
 import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-react-query'
 import { toast } from '@/components/ui/use-toast'
 import { useAccountExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
+import { useEmployeeExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
 
 interface AccountExportRequestsApprovalButtonProps {
   children: ReactNode
@@ -11,11 +12,14 @@ interface AccountExportRequestsApprovalButtonProps {
   exportId: string
 }
 
-const AccountExportRequestsApprovalButton: FC<
+const ExportRequestsApprovalButton: FC<
   AccountExportRequestsApprovalButtonProps
 > = ({ children, action, exportId }) => {
   const supabase = createBrowserClient()
-  const { setIsModalOpen } = useAccountExportRequestsContext()
+  const { setIsModalOpen: setAccountModalOpen } =
+    useAccountExportRequestsContext()
+  const { setIsModalOpen: setEmployeeModalOpen } =
+    useEmployeeExportRequestsContext()
 
   const { mutateAsync, isPending } = useUpdateMutation(
     //@ts-expect-error
@@ -28,7 +32,8 @@ const AccountExportRequestsApprovalButton: FC<
           title: `Request ${action === 'approve' ? 'approved' : 'rejected'}`,
           description: `The request has been ${action === 'approve' ? 'approved' : 'rejected'} successfully`,
         })
-        setIsModalOpen(false)
+        setAccountModalOpen(false)
+        setEmployeeModalOpen(false)
       },
       onError: () => {
         toast({
@@ -50,4 +55,4 @@ const AccountExportRequestsApprovalButton: FC<
   return <div onClick={handleApproval}> {children} </div>
 }
 
-export default AccountExportRequestsApprovalButton
+export default ExportRequestsApprovalButton

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal.tsx
@@ -9,9 +9,12 @@ import {
 } from '@/components/ui/dialog'
 import { useEmployeeExportRequestsContext } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
 import { formatDate } from 'date-fns'
+import ExportRequestsApprovalButton from '@/app/(dashboard)/admin/approval-request/components/export-requests-approval-button'
+import { Button } from '@/components/ui/button'
+import { Loader2 } from 'lucide-react'
 
 const EmployeeExportRequestsModal = () => {
-  const { isModalOpen, setIsModalOpen, selectedData } =
+  const { isModalOpen, setIsModalOpen, selectedData, isLoading } =
     useEmployeeExportRequestsContext()
 
   return (
@@ -40,7 +43,22 @@ const EmployeeExportRequestsModal = () => {
           ?
         </div>
         <div className="flex justify-end gap-x-2">
-          {/* TODO: Buttons for reject and approved*/}
+          <ExportRequestsApprovalButton
+            action="reject"
+            exportId={selectedData?.id as any}
+          >
+            <Button variant={'destructive'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Reject'}
+            </Button>
+          </ExportRequestsApprovalButton>
+          <ExportRequestsApprovalButton
+            action="approve"
+            exportId={selectedData?.id as any}
+          >
+            <Button variant={'default'} disabled={isLoading}>
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Approve'}
+            </Button>
+          </ExportRequestsApprovalButton>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
### TL;DR
Unified the export request approval functionality between account and employee exports.

### What changed?
- Renamed `AccountExportRequestsApprovalButton` to `ExportRequestsApprovalButton` and moved it to a shared components directory
- Added support for both account and employee export modal states in the approval button
- Implemented approval/reject buttons in the employee export requests modal
- Removed unused imports from account export request modal

### How to test?
1. Navigate to the admin approval request section
2. Test account export approval/rejection:
   - Open an account export request
   - Click approve/reject buttons
   - Verify modal closes and status updates
3. Test employee export approval/rejection:
   - Open an employee export request
   - Click approve/reject buttons
   - Verify modal closes and status updates

### Why make this change?
To reduce code duplication and maintain consistency in the approval flow between account and employee exports. This change makes the codebase more maintainable and provides a unified user experience for administrators handling different types of export requests.