### PR TITLE
TIM-739 Add file manager download page and navigation

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-downloads.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { File } from 'lucide-react'
+
+const AccountDownloads = () => {
+  return (
+    <div className="flex flex-row">
+      <div className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md">
+        {/*TODO: Add mapping for list of files*/}
+        <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
+        <div className="fixed bottom-14 left-12 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+          {' '}
+          XLS{' '}
+        </div>
+        <span className="text-xs font-medium text-[#1e293b]">
+          {' '}
+          Account File{' '}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default AccountDownloads

--- a/src/app/(dashboard)/(home)/file-manager/downloadable-files.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloadable-files.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import {
+  PageDescription,
+  PageHeader,
+  PageTitle,
+} from '@/components/page-header'
+import AccountDownloads from '@/app/(dashboard)/(home)/file-manager/account-downloads'
+import EmployeeDownloads from '@/app/(dashboard)/(home)/file-manager/employee-downloads'
+
+const DownloadableFiles = () => {
+  return (
+    <div className="flex flex-col">
+      <PageHeader>
+        <div className="flex w-full flex-col gap-6 sm:flex-row sm:justify-between">
+          <div>
+            <PageTitle>Download Export Files</PageTitle>
+            {/*TODO: Add count and loading state*/}
+            {/*{isPending ? (*/}
+            {/*  <Skeleton className="h-4 w-20" />*/}
+            {/*) : (*/}
+            {/*  <PageDescription>{count} file exports</PageDescription>*/}
+            {/*)}*/}
+            <PageDescription> files </PageDescription>
+          </div>
+        </div>
+      </PageHeader>
+      <div className="space-y-4 p-8">
+        <span className="text-sm font-medium"> Accounts </span>
+        <AccountDownloads />
+      </div>
+      <div className="space-y-4 p-8">
+        <span className="text-sm font-medium"> Employees </span>
+        <EmployeeDownloads />
+      </div>
+    </div>
+  )
+}
+
+export default DownloadableFiles

--- a/src/app/(dashboard)/(home)/file-manager/employee-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-downloads.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { File } from 'lucide-react'
+
+const EmployeeDownloads = () => {
+  return (
+    <div className="flex flex-row">
+      <div className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md">
+        {/*TODO: Add mapping for list of files*/}
+        <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
+        <div className="fixed bottom-14 left-12 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+          {' '}
+          XLS
+        </div>
+        <span className="text-xs font-medium text-[#1e293b]">
+          {' '}
+          Account File{' '}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default EmployeeDownloads

--- a/src/app/(dashboard)/(home)/file-manager/page.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import DownloadableFiles from '@/app/(dashboard)/(home)/file-manager/downloadable-files'
+
+const Page = () => {
+  return (
+    <>
+      <DownloadableFiles />
+    </>
+  )
+}
+
+export default Page

--- a/src/components/layout/navigation/navigation.tsx
+++ b/src/components/layout/navigation/navigation.tsx
@@ -7,7 +7,7 @@ import {
   SidebarMenu,
 } from '@/components/ui/sidebar'
 import getRole from '@/utils/get-role'
-import { Book, BookCopy, Gauge } from 'lucide-react'
+import { Book, BookCopy, Gauge, LucideDownload } from 'lucide-react'
 import NavigationItem from './navigation-item'
 
 const Navigation = async () => {
@@ -45,6 +45,18 @@ const Navigation = async () => {
                 />
               )
             }
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      <SidebarGroup>
+        <SidebarGroupLabel>File Manager</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            <NavigationItem
+              title="Download Files"
+              href="/file-manager"
+              icon={<LucideDownload className="h-6 w-6" />}
+            />
           </SidebarMenu>
         </SidebarGroupContent>
       </SidebarGroup>


### PR DESCRIPTION
### TL;DR
Added a new file manager section to download account and employee files

### What changed?
- Created a new file manager page with downloadable files interface
- Added file download components for both account and employee files
- Introduced a new navigation item under "File Manager" section
- Each download component displays an XLS file icon with appropriate labeling

### How to test?
1. Navigate to the dashboard
2. Look for the new "File Manager" section in the sidebar
3. Click on "Download Files"
4. Verify that both Account and Employee sections are visible
5. Confirm that file icons and XLS labels are properly displayed

### Why make this change?
To provide users with a dedicated interface for downloading account and employee-related files in XLS format, improving the accessibility and organization of exportable data within the application.