### PR TITLE
feat(dashboard): add commission earnings chart

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-card.tsx
@@ -1,0 +1,23 @@
+import CommissionChart from '@/app/(dashboard)/(home)/(dashboard)/commission/commission-chart'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const CommissionCard = () => {
+  return (
+    <Card className="col-span-1 md:col-span-3">
+      <CardHeader>
+        <CardTitle className="flex flex-row items-center justify-between">
+          <span className="text-base font-medium">Total Commission Earned</span>
+          <Badge variant="default" className="bg-muted text-muted-foreground">
+            Last 12 Months
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <CommissionChart />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default CommissionCard

--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import processChartData from '@/app/(dashboard)/(home)/(dashboard)/commission/process-commission-chart'
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { subMonths, startOfMonth } from 'date-fns'
+import { useEffect, useMemo } from 'react'
+import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
+
+const chartConfig = {
+  commission_earned: {
+    label: 'Commission Earned:',
+    color: 'hsl(210, 100%, 50%)',
+  },
+} satisfies ChartConfig
+
+const CommissionChart = () => {
+  const supabase = createBrowserClient()
+  const { data } = useQuery(
+    // @ts-ignore
+    supabase
+      .from('billing_statements')
+      .select('commission_earned, created_at, id')
+      .order('created_at', { ascending: true })
+      .eq('is_active', true)
+      .gte('created_at', subMonths(startOfMonth(new Date()), 12).toISOString()),
+  )
+
+  const processedData = useMemo(() => processChartData(data), [data])
+
+  return (
+    <ChartContainer config={chartConfig}>
+      <AreaChart
+        accessibilityLayer
+        data={processedData}
+        margin={{
+          left: 12,
+          right: 12,
+        }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value) => value.slice(0, 3)}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+        />
+        <Area
+          dataKey="commission_earned"
+          type="natural"
+          fill="hsl(210, 100%, 50%)"
+          fillOpacity={0.4}
+          stroke="hsl(210, 100%, 50%)"
+          stackId="a"
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}
+
+export default CommissionChart

--- a/src/app/(dashboard)/(home)/(dashboard)/commission/process-commission-chart.ts
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/process-commission-chart.ts
@@ -1,0 +1,46 @@
+const processChartData = (
+  data: { commission_earned: number; created_at: string }[] | null | undefined,
+): { month: string; commission_earned: number }[] => {
+  if (!data) {
+    return []
+  }
+
+  const result: { month: string; commission_earned: number }[] = []
+  const currentDate = new Date()
+  const startMonth = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth() - 11,
+    1,
+  )
+
+  for (let i = 0; i < 12; i++) {
+    const monthDate = new Date(
+      startMonth.getFullYear(),
+      startMonth.getMonth() + i,
+      1,
+    )
+    const monthString = monthDate.toLocaleString('default', {
+      month: 'long',
+      year: 'numeric',
+    })
+
+    const filteredData = data.filter((item) => {
+      const itemDate = new Date(item.created_at)
+      return (
+        itemDate.getFullYear() === monthDate.getFullYear() &&
+        itemDate.getMonth() === monthDate.getMonth()
+      )
+    })
+
+    const totalCommission = filteredData.reduce(
+      (sum, item) => sum + item.commission_earned,
+      0,
+    )
+
+    result.push({ month: monthString, commission_earned: totalCommission })
+  }
+
+  return result
+}
+
+export default processChartData

--- a/src/app/(dashboard)/(home)/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/page.tsx
@@ -6,6 +6,7 @@ import TopAgentsCard from '@/app/(dashboard)/(home)/(dashboard)/top-agents/top-a
 import { Metadata } from 'next'
 import PageTitle from './page-title'
 import RenewalCard from '@/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card'
+import CommissionCard from '@/app/(dashboard)/(home)/(dashboard)/commission/commission-card'
 
 export const metadata = async (): Promise<Metadata> => {
   return {
@@ -22,6 +23,7 @@ const Dashboard = () => {
         <RetentionRateCard />
         <TopAgentsCard />
         <RenewalCard />
+        <CommissionCard />
       </div>
     </div>
   )

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -195,8 +195,10 @@ END $$;
 DO $$
 DECLARE
     i integer;
+    random_created_at timestamp;
 BEGIN
     FOR i IN 1..500 LOOP
+        random_created_at := (current_date - interval '2 years') + (random() * (current_date - (current_date - interval '2 years')));
         INSERT INTO billing_statements (
             id,
             account_id,
@@ -233,7 +235,7 @@ BEGIN
             50.0 * i,
             5.0,
             25.0 * i,
-            now(),
+            random_created_at,
             now()
         );
     END LOOP;


### PR DESCRIPTION
### TL;DR
Added a new commission chart component to display total commission earned over the last 12 months.

### What changed?
- Created a new commission card component with a chart visualization
- Added data processing logic to aggregate commission data by month
- Integrated the commission chart into the dashboard layout
- Updated seed data to include randomized creation dates for billing statements

### How to test?
1. Run the database seed script to populate test data
2. Navigate to the dashboard page
3. Verify the commission card displays with a chart showing last 12 months of data
4. Confirm the tooltip shows correct commission values when hovering over data points
5. Check that the chart properly aggregates commission data by month

### Why make this change?
This visualization helps users track their commission earnings trends over time, providing valuable insights into their performance and revenue patterns. The 12-month view allows for better long-term analysis and identification of seasonal patterns in commission earnings.