### PR TITLE
feat(dashboard): adjust card heights and responsive layouts

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-card.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 const CommissionCard = () => {
   return (
-    <Card className="col-span-1 md:col-span-3">
+    <Card className="col-span-1 h-[490px] md:col-span-4 xl:col-span-3">
       <CardHeader>
         <CardTitle className="flex flex-row items-center justify-between">
           <span className="text-base font-medium">Total Commission Earned</span>

--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
@@ -35,7 +35,7 @@ const CommissionChart = () => {
   const processedData = useMemo(() => processChartData(data), [data])
 
   return (
-    <ChartContainer config={chartConfig}>
+    <ChartContainer config={chartConfig} className="h-[400px] w-full">
       <AreaChart
         accessibilityLayer
         data={processedData}

--- a/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card.tsx
@@ -9,7 +9,7 @@ import {
 
 const RenewalCard = () => {
   return (
-    <Card className="col-span-1">
+    <Card className="col-span-1 h-[490px] md:col-span-4 xl:col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">
           Upcoming Renewals

--- a/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-list.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-list.tsx
@@ -18,7 +18,7 @@ const RenewalList = () => {
   )
 
   return (
-    <div className="space-y-4">
+    <div className="max-h-[370px] space-y-4 overflow-y-auto">
       {data?.map((item) => (
         <RenewalItem key={item.id} data={item as Tables<'accounts'>} />
       ))}


### PR DESCRIPTION
### TL;DR
Improved responsive layout and scrolling behavior for dashboard cards

### What changed?
- Added fixed height (490px) to Commission and Renewal cards
- Updated column spans for better responsive behavior across different screen sizes
- Set explicit dimensions for Commission chart (400px height)
- Added scrollable behavior to Renewal list with max height of 370px

### How to test?
1. View dashboard at different screen sizes (mobile, tablet, desktop)
2. Verify Commission card spans correctly across breakpoints
3. Check that Commission chart renders properly with new dimensions
4. Add multiple renewal items and confirm scrolling works in Renewal card

### Why make this change?
To create a more consistent and polished dashboard layout that maintains proper spacing and alignment across all screen sizes while ensuring content remains accessible through scrolling when it exceeds the container height.