### PR TITLE
feat(dashboard): lazy load cards and add role-based visibility

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/page.tsx
@@ -3,10 +3,27 @@
 import ClientAcquisitionCard from '@/app/(dashboard)/(home)/(dashboard)/client-acquisition/client-acquisition-card'
 import RetentionRateCard from '@/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card'
 import TopAgentsCard from '@/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card'
+import getRole from '@/utils/get-role'
 import { Metadata } from 'next'
+import dynamic from 'next/dynamic'
 import PageTitle from './page-title'
-import RenewalCard from '@/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card'
-import CommissionCard from '@/app/(dashboard)/(home)/(dashboard)/commission/commission-card'
+
+const RenewalCard = dynamic(
+  () =>
+    import(
+      '@/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card'
+    ),
+  {
+    loading: () => <div>Loading...</div>,
+  },
+)
+const CommissionCard = dynamic(
+  () =>
+    import('@/app/(dashboard)/(home)/(dashboard)/commission/commission-card'),
+  {
+    loading: () => <div>Loading...</div>,
+  },
+)
 
 export const metadata = async (): Promise<Metadata> => {
   return {
@@ -14,7 +31,9 @@ export const metadata = async (): Promise<Metadata> => {
   }
 }
 
-const Dashboard = () => {
+const Dashboard = async () => {
+  const role = await getRole()
+
   return (
     <div className="p-6">
       <PageTitle title="Dashboard" description="Welcome to the dashboard" />
@@ -22,8 +41,13 @@ const Dashboard = () => {
         <ClientAcquisitionCard />
         <RetentionRateCard />
         <TopAgentsCard />
-        <RenewalCard />
-        <CommissionCard />
+
+        {(role === 'finance' || role === 'admin') && (
+          <>
+            <RenewalCard />
+            <CommissionCard />
+          </>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
### TL;DR
Added role-based access control for dashboard components and implemented dynamic loading for renewal and commission cards.

### What changed?
- Implemented dynamic imports for RenewalCard and CommissionCard components
- Added loading states for dynamically imported components
- Integrated role-based access control using `getRole` utility
- Restricted RenewalCard and CommissionCard visibility to users with 'finance' or 'admin' roles
- Made Dashboard component asynchronous to support role checking

### How to test?
1. Log in as different user roles (admin, finance, and other roles)
2. Verify that RenewalCard and CommissionCard are only visible for admin and finance roles
3. Verify that loading states appear while cards are being dynamically loaded
4. Confirm that other dashboard components remain visible for all roles

### Why make this change?
To enhance security and performance by:
- Restricting sensitive financial information to authorized roles
- Improving initial page load time through dynamic imports
- Implementing proper access control for dashboard components