### PR TITLE
fix(billing): change commission display from percentage to currency

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/billing-statements-columns.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/billing-statements-columns.tsx
@@ -105,7 +105,7 @@ const billingStatementsColumns: ColumnDef<Tables<'billing_statements'>>[] = [
       <TableHeader column={column} title="Commission Earned" />
     ),
     cell: ({ getValue }) =>
-      formatPercentage(getValue<number | null | undefined>()),
+      formatCurrency(getValue<number | null | undefined>()),
   },
 ]
 


### PR DESCRIPTION
### TL;DR
Changed the commission earned column to display as currency instead of percentage.

### What changed?
Updated the formatting of the commission earned column in the billing statements table from `formatPercentage` to `formatCurrency`.

### How to test?
1. Navigate to the billing statements table
2. Verify that the "Commission Earned" column displays values in currency format (e.g., $100.00) rather than percentage format

### Why make this change?
Commission earned values should be displayed as monetary amounts rather than percentages to accurately represent the actual earnings in the billing statements.