### PR TITLE
fix(forms): disable email field editing

### DIFF
--- a/src/app/(dashboard)/admin/agents/edit/edit-agent-form.tsx
+++ b/src/app/(dashboard)/admin/agents/edit/edit-agent-form.tsx
@@ -126,7 +126,7 @@ const EditAgentForm: FC<Props> = ({
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input {...field} disabled={isLoading} />
+                  <Input {...field} disabled={true} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/app/(dashboard)/admin/users/edit/edit-user-form.tsx
+++ b/src/app/(dashboard)/admin/users/edit/edit-user-form.tsx
@@ -1,4 +1,3 @@
-import ConfirmEmail from '@/app/(dashboard)/admin/users/edit/confirm-email'
 import DeleteUser from '@/app/(dashboard)/admin/users/edit/delete-user'
 import userSchema from '@/app/(dashboard)/admin/users/user-schema'
 import Message from '@/components/message'
@@ -144,7 +143,7 @@ const EditUserForm: FC<Props> = ({
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input {...field} disabled={isLoading} />
+                  <Input {...field} disabled={true} />
                 </FormControl>
                 <FormMessage />
               </FormItem>


### PR DESCRIPTION
### TL;DR
Disabled email field editing for both users and agents in the admin forms.

### What changed?
- Made email fields permanently disabled in both user and agent edit forms
- Removed unused `ConfirmEmail` import from edit-user-form
- Replaced `disabled={isLoading}` with `disabled={true}` for email input fields

### How to test?
1. Navigate to the admin dashboard
2. Try to edit a user or agent
3. Verify that the email field is disabled and cannot be edited
4. Confirm that all other form fields remain editable

### Why make this change?
Email addresses serve as unique identifiers in the system and should not be modifiable after creation to maintain data integrity and prevent potential security issues. This change enforces this constraint at the UI level.