### PR TITLE
fix(admin): replace undefined with dash in approval info

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/accounts/approval-request-info.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/approval-request-info.tsx
@@ -66,7 +66,7 @@ const ApprovalRequestInfo = () => {
                         normalizeToUTC(new Date(selectedData.expiration_date)),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -77,7 +77,7 @@ const ApprovalRequestInfo = () => {
                         normalizeToUTC(new Date(selectedData.effectivity_date)),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -88,7 +88,7 @@ const ApprovalRequestInfo = () => {
                         normalizeToUTC(new Date(selectedData.coc_issue_date)),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -103,7 +103,7 @@ const ApprovalRequestInfo = () => {
                         ),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -114,7 +114,7 @@ const ApprovalRequestInfo = () => {
                         normalizeToUTC(new Date(selectedData.orientation_date)),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -127,7 +127,7 @@ const ApprovalRequestInfo = () => {
                         ),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -142,7 +142,7 @@ const ApprovalRequestInfo = () => {
                         ),
                         'PP',
                       )
-                    : 'undefined'
+                    : '-'
                 }
               />
             </div>
@@ -165,9 +165,9 @@ const ApprovalRequestInfo = () => {
               <ApprovalInformationItem
                 label={'Commission Rate'}
                 value={
-                  selectedData?.commision_rate !== undefined
+                  selectedData?.commision_rate
                     ? formatPercentage(selectedData.commision_rate)
-                    : 'undefined'
+                    : '-'
                 }
               />
             </div>
@@ -248,7 +248,7 @@ const ApprovalRequestInfo = () => {
                 value={
                   selectedData?.total_utilization
                     ? formatCurrency(selectedData.total_utilization)
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem
@@ -256,7 +256,7 @@ const ApprovalRequestInfo = () => {
                 value={
                   selectedData?.total_premium_paid
                     ? formatCurrency(selectedData.total_premium_paid)
-                    : 'undefined'
+                    : '-'
                 }
               />
               <ApprovalInformationItem


### PR DESCRIPTION
### TL;DR
Updated undefined fallback values to display a dash (-) in the approval request information panel

### What changed?
Replaced all instances of 'undefined' string fallbacks with a dash (-) character in the ApprovalRequestInfo component. This affects various fields including dates, commission rates, and currency values.

### How to test?
1. Navigate to the admin approval request page
2. View an approval request with missing or undefined values
3. Verify that a dash (-) appears instead of the word 'undefined'
4. Check this behavior for:
   - Date fields (expiration, effectivity, COC issue, etc.)
   - Commission rate
   - Total utilization
   - Total premium paid

### Why make this change?
Displaying 'undefined' as text is not user-friendly and can be confusing for end users. Using a dash (-) is a more conventional and cleaner way to represent missing or undefined values in a UI.