### PR TITLE
feat(settings): add account settings page and user menu links

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -2,17 +2,12 @@
 
 import { FC, ReactNode } from 'react'
 import Header from '../../components/layout/header'
-import Navbar from '../../components/layout/navbar'
 
-import { cookies } from 'next/headers'
-import { createServerClient } from '@/utils/supabase'
-import { redirect } from 'next/navigation'
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from '@/components/ui/sidebar'
 import AppSidebar from '@/components/layout/navigation/app-sidebar'
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
+import { createServerClient } from '@/utils/supabase'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 
 interface Props {
   children: ReactNode

--- a/src/app/(dashboard)/settings/account/page.tsx
+++ b/src/app/(dashboard)/settings/account/page.tsx
@@ -1,0 +1,5 @@
+const AccountSettings = () => {
+  return <div>AccountSettings</div>
+}
+
+export default AccountSettings

--- a/src/components/layout/navigation/nav-user.tsx
+++ b/src/components/layout/navigation/nav-user.tsx
@@ -1,11 +1,21 @@
 'use client'
 
-import { ChevronsUpDown } from 'lucide-react'
+import {
+  Bell,
+  BadgeCheck,
+  ChevronsUpDown,
+  CreditCard,
+  Settings,
+  Lock,
+  UserCog,
+} from 'lucide-react'
 
 import SignOutButton from '@/components/layout/signout-button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -21,6 +31,7 @@ import { User } from '@supabase/supabase-js'
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
 import { genConfig } from 'react-nice-avatar'
+import Link from 'next/link'
 
 const Avatar = dynamic(() => import('react-nice-avatar'), {
   ssr: true,
@@ -73,29 +84,30 @@ const NavUser = ({ user }: { user?: User | null }) => {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            {/* <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <Sparkles />
-                Upgrade to Pro
+            <DropdownMenuGroup>
+              <DropdownMenuItem asChild={true}>
+                <Link
+                  href="/settings/account"
+                  className="flex cursor-pointer flex-row items-center justify-start gap-4"
+                >
+                  <UserCog className="h-4 w-4" />
+                  Account
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild={true}>
+                <Link
+                  href="/settings/security"
+                  className="flex cursor-pointer flex-row items-center justify-start gap-4"
+                >
+                  <Lock className="h-4 w-4" />
+                  Security
+                </Link>
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <BadgeCheck />
-                Account
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <CreditCard />
-                Billing
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Bell />
-                Notifications
-              </DropdownMenuItem>
+              <SignOutButton />
             </DropdownMenuGroup>
-            <DropdownMenuSeparator /> */}
-            <SignOutButton />
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>


### PR DESCRIPTION
### TL;DR
Added user account settings navigation and placeholder page

### What changed?
- Created a new account settings page at `/settings/account`
- Enhanced the user navigation dropdown menu with links to account and security settings
- Added icons for better visual hierarchy in the navigation menu
- Reorganized the dropdown menu structure with proper grouping and separators

### How to test?
1. Log in to the application
2. Click on the user avatar in the navigation
3. Verify new "Account" and "Security" options are visible in the dropdown
4. Click "Account" to ensure it navigates to the new settings page
5. Verify the sign-out button is still accessible and functional

### Why make this change?
To provide users with easy access to account management features and establish a foundation for implementing account settings functionality. This improves the overall user experience by making account-related actions more discoverable and accessible.