### PR TITLE
feat(settings): add responsive navigation layout

### DIFF
--- a/src/app/(dashboard)/settings/(layout)/settings-nav-item.tsx
+++ b/src/app/(dashboard)/settings/(layout)/settings-nav-item.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { cn } from '@/utils/tailwind'
+import { IconNode } from 'lucide-react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ComponentType } from 'react'
+
+interface SettingsNavItemProps {
+  name: string
+  description: string
+  url: string
+  icon: ComponentType<{ className?: string }>
+}
+
+const SettingsNavItem = ({
+  name,
+  description,
+  url,
+  icon: Icon,
+}: SettingsNavItemProps) => {
+  const path = usePathname()
+  const isActive = path.includes(url)
+
+  return (
+    <Link
+      href={url}
+      className={cn(
+        isActive ? 'bg-primary/10' : 'hover:bg-muted',
+        'flex max-h-28 w-full cursor-pointer flex-row items-start justify-start gap-3 px-8 py-5 sm:w-96',
+      )}
+    >
+      <Icon
+        className={cn(
+          isActive ? 'text-primary' : 'text-foreground/80',
+          'h-6 w-6',
+        )}
+      />
+      <div className="flex flex-col gap-0.5">
+        <span
+          className={cn(
+            isActive ? 'text-primary' : 'text-foreground/80',
+            'text-left text-sm font-medium',
+          )}
+        >
+          {name}
+        </span>
+        <span className="text-sm text-muted-foreground/70">{description}</span>
+      </div>
+    </Link>
+  )
+}
+
+export default SettingsNavItem

--- a/src/app/(dashboard)/settings/(layout)/settings-navigation.tsx
+++ b/src/app/(dashboard)/settings/(layout)/settings-navigation.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import SettingsNavItem from '@/app/(dashboard)/settings/(layout)/settings-nav-item'
+import { useSettingsContext } from '@/app/(dashboard)/settings/(layout)/settings-provider'
+import { Button } from '@/components/ui/button'
+import { UserCog, X, Lock } from 'lucide-react'
+import { ComponentType, useState } from 'react'
+
+const navigationLinks: {
+  name: string
+  description: string
+  url: string
+  icon: ComponentType<{ className?: string }>
+}[] = [
+  {
+    name: 'Account',
+    description: 'Manage your account settings',
+    url: '/settings/account',
+    icon: UserCog,
+  },
+  {
+    name: 'Security',
+    description: 'Manage your security settings',
+    url: '/settings/security',
+    icon: Lock,
+  },
+]
+
+const SettingsNavigation = () => {
+  const { isOpen, setIsOpen } = useSettingsContext()
+
+  return (
+    <div
+      data-open={isOpen}
+      className="absolute -left-[600px] z-20 h-[calc(100vh-64px)] w-full border-r border-border bg-white transition-all duration-1000 data-[open=true]:left-0 sm:-left-96 sm:w-96 md:-left-24 md:-z-10 md:data-[open=true]:left-72 md:data-[open=true]:z-20 lg:relative lg:left-0 lg:z-20 lg:transition-none"
+    >
+      <div className="flex flex-row items-center justify-between px-8 py-9">
+        <h2 className="text-3xl font-extrabold">Settings</h2>
+
+        <Button
+          variant={'ghost'}
+          size={'icon'}
+          className="lg:hidden"
+          onClick={() => setIsOpen(false)}
+        >
+          <X className="h-5 w-5" />
+        </Button>
+      </div>
+      <div className="divide-y divide-border border-y border-border">
+        {navigationLinks.map((link) => (
+          <SettingsNavItem {...link} key={link.url} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default SettingsNavigation

--- a/src/app/(dashboard)/settings/(layout)/settings-page-title.tsx
+++ b/src/app/(dashboard)/settings/(layout)/settings-page-title.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { useSettingsContext } from '@/app/(dashboard)/settings/(layout)/settings-provider'
+import { Button } from '@/components/ui/button'
+import { Menu } from 'lucide-react'
+import { FC } from 'react'
+
+interface Props {
+  title: string
+}
+
+const SettingsPageTitle: FC<Props> = ({ title }) => {
+  const { setIsOpen } = useSettingsContext()
+  return (
+    <div className="flex flex-row items-center gap-1 px-3 lg:px-12">
+      <Button
+        variant={'ghost'}
+        size={'icon'}
+        onClick={() => setIsOpen(true)}
+        className="lg:hidden"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+      <h1 className="text-2xl font-bold">{title}</h1>
+    </div>
+  )
+}
+
+export default SettingsPageTitle

--- a/src/app/(dashboard)/settings/(layout)/settings-provider.tsx
+++ b/src/app/(dashboard)/settings/(layout)/settings-provider.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+const useSettingsContext = () => {
+  const context = useContext(SettingsContext)
+  if (!context) {
+    throw new Error('useSettingsContext must be used within a SettingsProvider')
+  }
+  return context
+}
+
+const SettingsContext = createContext<{
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+}>({ isOpen: false, setIsOpen: () => {} })
+
+const SettingsProvider = ({ children }: { children: ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <SettingsContext.Provider value={{ isOpen, setIsOpen }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export { useSettingsContext, SettingsProvider }

--- a/src/app/(dashboard)/settings/account/page.tsx
+++ b/src/app/(dashboard)/settings/account/page.tsx
@@ -1,5 +1,12 @@
+import SettingsPageTitle from '@/app/(dashboard)/settings/(layout)/settings-page-title'
+
 const AccountSettings = () => {
-  return <div>AccountSettings</div>
+  return (
+    <>
+      <SettingsPageTitle title="Account Settings" />
+      HEHE
+    </>
+  )
 }
 
 export default AccountSettings

--- a/src/app/(dashboard)/settings/layout.tsx
+++ b/src/app/(dashboard)/settings/layout.tsx
@@ -1,0 +1,18 @@
+import SettingsNavigation from '@/app/(dashboard)/settings/(layout)/settings-navigation'
+import { SettingsProvider } from '@/app/(dashboard)/settings/(layout)/settings-provider'
+import { Button } from '@/components/ui/button'
+import { X } from 'lucide-react'
+import { FC, ReactNode } from 'react'
+
+const SettingsLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <SettingsProvider>
+      <div className="flex w-full flex-row">
+        <SettingsNavigation />
+        <div className="w-full pt-9">{children}</div>
+      </div>
+    </SettingsProvider>
+  )
+}
+
+export default SettingsLayout


### PR DESCRIPTION
### TL;DR
Added a responsive settings navigation layout with account and security sections.

### What changed?
- Created a new settings navigation component with a sidebar layout
- Implemented navigation items for Account and Security sections
- Added a settings context provider to manage sidebar state
- Built a responsive layout that adapts to mobile, tablet, and desktop views
- Created a page title component with a mobile menu toggle

### How to test?
1. Navigate to `/settings/account` or `/settings/security`
2. Verify the sidebar navigation appears and is functional
3. Test responsive behavior:
   - On desktop: Sidebar should be permanently visible
   - On mobile/tablet: Sidebar should slide in/out using the menu button
4. Confirm active state styling when navigating between sections
5. Verify smooth transitions and animations for the sidebar

### Why make this change?
To provide users with an intuitive and accessible way to navigate between different settings sections while maintaining a consistent layout across all device sizes. The responsive design ensures a seamless experience on both mobile and desktop platforms.