### PR TITLE
TIM-741 Refactor downloads provider and add employee downloads sheet

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
@@ -9,12 +9,12 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import AccountDownloadsSheet from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-sheet'
-import { useAccountDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-provider'
+import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 import { Button } from '@/components/ui/button'
 import AccountDownloadsButton from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button'
 
 const AccountDownloads = () => {
-  const { setIsSheetOpen } = useAccountDownloadsContext()
+  const { setIsSheetOpen } = useDownloadsContext()
   const handleClick = () => {
     setIsSheetOpen(true)
   }

--- a/src/app/(dashboard)/(home)/file-manager/downloadable-files.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloadable-files.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 import {
   PageDescription,

--- a/src/app/(dashboard)/(home)/file-manager/downloads-provider.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloads-provider.tsx
@@ -2,28 +2,28 @@
 import React from 'react'
 import { createContext, ReactNode, useContext, useState } from 'react'
 
-const useAccountDownloadsContext = () => {
-  const context = useContext(AccountDownloadsContext)
+const useDownloadsContext = () => {
+  const context = useContext(DownloadsContext)
   if (!context) {
     throw new Error(
-      'useAccountDownloadsContext must be used within a AccountDownloadsProvider',
+      'useAccountDownloadsContext must be used within a DownloadsProvider',
     )
   }
   return context
 }
 
-const AccountDownloadsContext = createContext({
+const DownloadsContext = createContext({
   isSheetOpen: false,
   setIsSheetOpen: (_value: boolean) => {},
   isLoading: false,
   setIsLoading: (_value: boolean) => {},
 })
 
-const AccountDownloadsProvider = ({ children }: { children: ReactNode }) => {
+const DownloadsProvider = ({ children }: { children: ReactNode }) => {
   const [isSheetOpen, setIsSheetOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   return (
-    <AccountDownloadsContext.Provider
+    <DownloadsContext.Provider
       value={{
         isSheetOpen,
         setIsSheetOpen,
@@ -32,8 +32,8 @@ const AccountDownloadsProvider = ({ children }: { children: ReactNode }) => {
       }}
     >
       {children}
-    </AccountDownloadsContext.Provider>
+    </DownloadsContext.Provider>
   )
 }
 
-export { AccountDownloadsProvider, useAccountDownloadsContext }
+export { DownloadsProvider, useDownloadsContext }

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-button.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-button.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+
+const EmployeeDownloadsButton = () => {
+  return (
+    <>
+      <Button className="w-full">Export File</Button>
+      <Button variant="outline" className="w-full">
+        Cancel
+      </Button>
+    </>
+  )
+}
+
+export default EmployeeDownloadsButton

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-sheet.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-sheet.tsx
@@ -1,0 +1,44 @@
+'use client'
+import React from 'react'
+import { SheetHeader } from '@/components/ui/sheet'
+import { Separator } from '@/components/ui/separator'
+import { File } from 'lucide-react'
+
+const EmployeeDownloadsSheet = () => {
+  return (
+    <div className="space-y-8 p-12">
+      <SheetHeader className="items-center justify-center">
+        <div className="flex h-[235px] w-[352px] items-center justify-center rounded-lg border bg-background p-8">
+          <File className="h-24 w-24 text-[#94a3b8]" />
+        </div>
+      </SheetHeader>
+      <div className="space-y-2">
+        <span className="text-xl font-medium text-[#1e293b]">Account File</span>
+        <div className="h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+          {' '}
+          XLS{' '}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <span className="text-lg font-medium">Information</span>
+        <Separator />
+        <div className=" flex flex-row justify-between pb-1 pt-1 ">
+          <span className="text-sm font-medium text-[#64748b]">
+            Approved at
+          </span>
+          <span className="text-sm text-[#1e293b]">November 15, 2024</span>
+        </div>
+        <Separator />
+        <div className=" flex flex-row justify-between pb-1 pt-1 ">
+          <span className="text-sm font-medium text-[#64748b]">
+            Approved by
+          </span>
+          <span className="text-sm text-[#1e293b]">Jane Doe</span>
+        </div>
+        <Separator />
+      </div>
+    </div>
+  )
+}
+
+export default EmployeeDownloadsSheet

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
@@ -1,21 +1,60 @@
+'use client'
 import React from 'react'
-import { File } from 'lucide-react'
+import { File, X } from 'lucide-react'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetFooter,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
+import EmployeeDownloadsSheet from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-sheet'
+import EmployeeDownloadsButton from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-button'
 
 const EmployeeDownloads = () => {
+  const { setIsSheetOpen } = useDownloadsContext()
+  const handleClick = () => {
+    setIsSheetOpen(true)
+  }
+
   return (
     <div className="flex flex-row">
-      <div className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md">
-        {/*TODO: Add mapping for list of files*/}
-        <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
-        <div className="fixed bottom-14 left-12 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
-          {' '}
-          XLS
-        </div>
-        <span className="text-xs font-medium text-[#1e293b]">
-          {' '}
-          Account File{' '}
-        </span>
-      </div>
+      <Sheet>
+        <SheetTrigger
+          onClick={handleClick}
+          asChild={true}
+          className="hover:cursor-pointer"
+        >
+          <div className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md">
+            {/*TODO: Add mapping for list of files*/}
+            <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
+            <div className="fixed bottom-14 left-12 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+              {' '}
+              XLS{' '}
+            </div>
+            <span className="text-xs font-medium text-[#1e293b]">
+              {' '}
+              Account File{' '}
+            </span>
+          </div>
+        </SheetTrigger>
+        <SheetContent className="xs:w-screen flex w-screen flex-col justify-between overflow-auto bg-card sm:max-w-none md:max-w-md">
+          <div className="flex flex-col items-end px-7 py-5">
+            <SheetClose asChild={true}>
+              <Button variant={'ghost'} size={'icon'}>
+                <X />
+              </Button>
+            </SheetClose>
+          </div>
+          <EmployeeDownloadsSheet />
+          <SheetFooter className="mt-auto flex flex-row items-center justify-between gap-4 p-12">
+            {/*  TODO : Buttons functionality */}
+            <EmployeeDownloadsButton />
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/src/app/(dashboard)/(home)/file-manager/page.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/page.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import DownloadableFiles from '@/app/(dashboard)/(home)/file-manager/downloadable-files'
-import { AccountDownloadsProvider } from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-provider'
+import { DownloadsProvider } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 
 const Page = () => {
   return (
     <>
-      <AccountDownloadsProvider>
+      <DownloadsProvider>
         <DownloadableFiles />
-      </AccountDownloadsProvider>
+      </DownloadsProvider>
     </>
   )
 }


### PR DESCRIPTION
### TL;DR
Added employee downloads functionality and refactored downloads context provider for better reusability. HTML/CSS only.

### What changed?
- Created new employee downloads components including button, sheet, and downloads UI
- Renamed `AccountDownloadsProvider` to `DownloadsProvider` for broader usage
- Updated context usage across components to use the renamed provider
- Added sheet functionality to employee downloads with export and cancel actions
- Implemented file preview and information display in employee downloads sheet

### How to test?
1. Navigate to the file manager dashboard
2. Click on an employee file card to open the downloads sheet
3. Verify the file preview and information is displayed correctly
4. Confirm the Export File and Cancel buttons are present
5. Test sheet opening/closing functionality
6. Verify the context provider works for both account and employee downloads

### Why make this change?
To provide a consistent file download experience across both account and employee sections while maintaining a single source of truth for download-related state management. This change improves code reusability and maintains UI consistency throughout the application.