### PR TITLE
feat(settings): add security page with password update form

### DIFF
--- a/src/app/(dashboard)/settings/security/page.tsx
+++ b/src/app/(dashboard)/settings/security/page.tsx
@@ -1,0 +1,15 @@
+import SettingsPageTitle from '@/app/(dashboard)/settings/(layout)/settings-page-title'
+import SecurityForm from '@/app/(dashboard)/settings/security/security-form'
+
+const SecuritySettings = () => {
+  return (
+    <>
+      <SettingsPageTitle title="Security" />
+      <div className="mt-9 flex w-full max-w-3xl flex-col px-5 lg:px-12">
+        <SecurityForm />
+      </div>
+    </>
+  )
+}
+
+export default SecuritySettings

--- a/src/app/(dashboard)/settings/security/security-schema.ts
+++ b/src/app/(dashboard)/settings/security/security-schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const SecuritySchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, { message: 'Password must be at least 8 characters long' }),
+    confirmPassword: z
+      .string()
+      .min(8, { message: 'Password must be at least 8 characters long' }),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+      })
+    }
+  })
+
+export type SecuritySchema = z.infer<typeof SecuritySchema>


### PR DESCRIPTION
### TL;DR
Added a new security settings page allowing users to update their password with validation.

### What changed?
- Created a new security settings page with a password update form
- Added form validation using Zod schema to ensure passwords match and meet minimum requirements
- Implemented error handling and success notifications for password updates
- Enhanced the account form with improved error message display

### How to test?
1. Navigate to the security settings page
2. Attempt to update password with:
   - Passwords less than 8 characters (should show validation error)
   - Non-matching passwords (should show validation error)
   - Valid matching passwords (should update successfully)
3. Verify error messages display correctly
4. Verify success toast appears after successful password update

### Why make this change?
To provide users with a secure and user-friendly way to update their account passwords while ensuring proper validation and feedback throughout the process.