### PR TITLE
TIM-731 feat(home): add top hmo provider card

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   '@radix-ui/react-popover':
     specifier: ^1.0.7
     version: 1.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-progress':
+    specifier: ^1.1.0
+    version: 1.1.0(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-select':
     specifier: ^2.0.0
     version: 2.1.1(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
@@ -4294,6 +4297,27 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.2.8)(react@18.2.0)
+      '@types/react': 18.2.8
+      '@types/react-dom': 18.2.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-progress@1.1.0(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.5)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.8
       '@types/react-dom': 18.2.5
       react: 18.2.0

--- a/src/app/(dashboard)/(home)/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/page.tsx
@@ -7,6 +7,7 @@ import getRole from '@/utils/get-role'
 import { Metadata } from 'next'
 import dynamic from 'next/dynamic'
 import PageTitle from './page-title'
+import TopHmoCard from '@/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-card'
 
 const RenewalCard = dynamic(
   () =>
@@ -39,8 +40,9 @@ const Dashboard = async () => {
       <PageTitle title="Dashboard" description="Welcome to the dashboard" />
       <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-4">
         <ClientAcquisitionCard />
-        <RetentionRateCard />
         <TopAgentsCard />
+        <RetentionRateCard />
+        <TopHmoCard />
 
         {(role === 'finance' || role === 'admin') && (
           <>

--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
@@ -12,7 +12,7 @@ const RetentionRateCard = () => {
   const lastMonth = subMonths(new Date(), 1)
 
   return (
-    <Card className="col-span-1 md:col-span-2">
+    <Card className="col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">Retention Rate</CardTitle>
         <CardDescription className="text-xs font-medium">

--- a/src/app/(dashboard)/(home)/(dashboard)/top-hmo/count-hmo.ts
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-hmo/count-hmo.ts
@@ -1,0 +1,25 @@
+const countHmo = (
+  data: { hmo_provider: { name: string } | null }[] | null | undefined,
+): { hmo_provider: string; count: number; percentage: number }[] => {
+  if (!data) return []
+
+  const total = data.length
+  const hmoCountMap: { [key: string]: number } = {}
+
+  // Count occurrences of each hmo_provider
+  data.forEach((item) => {
+    const providerName = item.hmo_provider?.name
+    if (providerName) {
+      hmoCountMap[providerName] = (hmoCountMap[providerName] || 0) + 1
+    }
+  })
+
+  // Convert the count map to the desired output format
+  return Object.entries(hmoCountMap).map(([hmo_provider, count]) => ({
+    hmo_provider,
+    count,
+    percentage: (count / total) * 100,
+  }))
+}
+
+export default countHmo

--- a/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-card.tsx
@@ -1,0 +1,19 @@
+import TopHmoList from '@/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-list'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+const TopHmoCard = () => {
+  return (
+    <Card className="col-span-1">
+      <CardHeader>
+        <CardTitle className="text-base font-medium">
+          Top HMO Providers
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TopHmoList />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default TopHmoCard

--- a/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-list.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-list.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import countHmo from '@/app/(dashboard)/(home)/(dashboard)/top-hmo/count-hmo'
+import { Progress } from '@/components/ui/progress'
+import { createBrowserClient } from '@/utils/supabase'
+import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+
+const getColorClass = (percentage: number) => {
+  if (percentage < 5) {
+    return 'bg-red-500'
+  } else if (percentage < 15) {
+    return 'bg-orange-500'
+  } else if (percentage < 30) {
+    return 'bg-yellow-500'
+  } else {
+    return 'bg-green-500'
+  }
+}
+
+const TopHmoList = () => {
+  const supabase = createBrowserClient()
+  const { data, error } = useQuery(
+    supabase
+      .from('accounts')
+      .select('hmo_provider:hmo_provider_id(name), company_name')
+      .eq('is_active', true)
+      .eq('is_account_active', true)
+      .throwOnError(),
+  )
+
+  const hmoData = countHmo(
+    data as unknown as {
+      hmo_provider: { name: string }
+      company_name: string
+    }[],
+  )
+
+  // Sort the hmoData by count in descending order
+  const sortedHmoData = hmoData.sort((a, b) => b.count - a.count)
+
+  // Limit to top 3 HMO providers
+  const topThreeHmoData = sortedHmoData.slice(0, 3)
+
+  if (error) {
+    return <div>Error loading data</div>
+  }
+
+  if (!data) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <ul className="space-y-6">
+      {topThreeHmoData.map((provider, index) => {
+        const colorClass = getColorClass(provider.percentage)
+        return (
+          <li key={provider.hmo_provider} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="font-semibold">{provider.hmo_provider}</span>
+              <span className="text-sm text-muted-foreground">
+                {provider.count} accounts
+              </span>
+            </div>
+            <Progress value={provider.percentage} indicatorColor={colorClass} />
+            <div className="flex items-center justify-between text-xs">
+              <span
+                className={`font-medium ${colorClass.replace('bg-', 'text-')}`}
+              >
+                Rank {index + 1}
+              </span>
+              <span className="text-muted-foreground">
+                {provider.percentage.toFixed(2)}%
+              </span>
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default TopHmoList

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import * as React from 'react'
+import * as ProgressPrimitive from '@radix-ui/react-progress'
+import { cn } from '@/utils/tailwind'
+
+interface CustomProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorColor?: string
+}
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  CustomProgressProps
+>(({ className, value, indicatorColor, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative h-4 w-full overflow-hidden rounded-full bg-muted',
+      className,
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={`h-full w-full flex-1  transition-all ${indicatorColor || 'bg-primary'}`}
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }


### PR DESCRIPTION
### TL;DR
Added a new Top HMO Providers card to the dashboard that displays the top 3 HMO providers with visual progress indicators.

### What changed?
- Added a new Top HMO Providers dashboard card component
- Implemented progress bars with color-coded indicators based on percentage thresholds
- Created utility function to calculate HMO provider statistics
- Added @radix-ui/react-progress package for progress bar functionality
- Integrated the card into the main dashboard layout

### How to test?
1. Navigate to the dashboard
2. Locate the Top HMO Providers card
3. Verify that:
   - The top 3 HMO providers are displayed
   - Each provider shows account count and percentage
   - Progress bars are color-coded (red < 5%, orange < 15%, yellow < 30%, green >= 30%)
   - Rankings are correctly displayed
   - Data updates when accounts are modified

### Why make this change?
To provide better visibility into HMO provider distribution across accounts, helping stakeholders quickly identify the most prevalent providers and make informed business decisions based on provider usage patterns.