### PR TITLE
feat(dashboard): update card grid responsiveness

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/retention-rate/retention-rate-card.tsx
@@ -12,7 +12,7 @@ const RetentionRateCard = () => {
   const lastMonth = subMonths(new Date(), 1)
 
   return (
-    <Card className="col-span-1">
+    <Card className="col-span-1 md:col-span-4 lg:col-span-2 xl:col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">Retention Rate</CardTitle>
         <CardDescription className="text-xs font-medium">

--- a/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-agents/top-agents-card.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 const TopAgentsCard = () => {
   return (
-    <Card className="col-span-1 md:col-span-2">
+    <Card className="col-span-1 md:col-span-4 lg:col-span-2">
       <CardHeader>
         <CardTitle className="flex flex-row items-center justify-between">
           <span className="text-base font-medium">Top Agents</span>

--- a/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/top-hmo/top-hmo-card.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 const TopHmoCard = () => {
   return (
-    <Card className="col-span-1">
+    <Card className="col-span-1 md:col-span-4 lg:col-span-2 xl:col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">
           Top HMO Providers

--- a/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/upcoming-renewals/renewal-card.tsx
@@ -9,7 +9,7 @@ import {
 
 const RenewalCard = () => {
   return (
-    <Card className="col-span-1 h-[490px] md:col-span-4 xl:col-span-1">
+    <Card className="col-span-1 h-[490px] md:col-span-4 lg:col-span-2 xl:col-span-1">
       <CardHeader>
         <CardTitle className="text-base font-medium">
           Upcoming Renewals


### PR DESCRIPTION
### TL;DR
Updated responsive grid layouts for dashboard cards to improve mobile and tablet display.

### What changed?
- Modified grid column spans for dashboard cards using Tailwind CSS classes
- Added breakpoints for medium (md), large (lg), and extra-large (xl) screen sizes
- Adjusted card layouts for Retention Rate, Top Agents, Top HMO, and Upcoming Renewals components

### How to test?
1. Open the dashboard on different screen sizes (mobile, tablet, desktop)
2. Verify cards stack properly on mobile devices
3. Confirm cards display in a 2-column layout on tablet/medium screens
4. Ensure cards expand to 4-columns on large screens
5. Check that cards revert to single column on extra-large screens where specified

### Why make this change?
To enhance the dashboard's responsiveness and improve user experience across different device sizes. The new layout provides better content organization and readability on mobile and tablet devices while maintaining an optimal viewing experience on larger screens.