### PR TITLE
fix(commission): use or_date instead of created_at for chart data

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
@@ -26,11 +26,13 @@ const CommissionChart = () => {
     // @ts-ignore
     supabase
       .from('billing_statements')
-      .select('commission_earned, created_at, id')
+      .select('commission_earned, or_date, id')
       .order('created_at', { ascending: true })
       .eq('is_active', true)
       .gte('created_at', subMonths(startOfMonth(new Date()), 12).toISOString()),
   )
+
+  console.log(data)
 
   const processedData = useMemo(() => processChartData(data), [data])
 

--- a/src/app/(dashboard)/(home)/(dashboard)/commission/process-commission-chart.ts
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/process-commission-chart.ts
@@ -1,5 +1,8 @@
 const processChartData = (
-  data: { commission_earned: number; created_at: string }[] | null | undefined,
+  data:
+    | { commission_earned: number; or_date: string | null | undefined }[]
+    | null
+    | undefined,
 ): { month: string; commission_earned: number }[] => {
   if (!data) {
     return []
@@ -25,7 +28,8 @@ const processChartData = (
     })
 
     const filteredData = data.filter((item) => {
-      const itemDate = new Date(item.created_at)
+      if (!item.or_date) return false
+      const itemDate = new Date(item.or_date)
       return (
         itemDate.getFullYear() === monthDate.getFullYear() &&
         itemDate.getMonth() === monthDate.getMonth()

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -196,9 +196,11 @@ DO $$
 DECLARE
     i integer;
     random_created_at timestamp;
+    random_or_date timestamp;
 BEGIN
     FOR i IN 1..500 LOOP
         random_created_at := (current_date - interval '2 years') + (random() * (current_date - (current_date - interval '2 years')));
+        random_or_date := (current_date - interval '1 year') + (random() * (current_date - (current_date - interval '1 year')));
         INSERT INTO billing_statements (
             id,
             account_id,
@@ -224,7 +226,7 @@ BEGIN
             (SELECT id FROM mode_of_payments LIMIT 1 OFFSET floor(random() * (SELECT count(*) FROM mode_of_payments))),
             current_date + (i * interval '1 month'),
             'OR' || i,
-            current_date + (i * interval '1 month'),
+            random_or_date,
             'SA' || i,
             100.0 * i,
             1000.0 * i,


### PR DESCRIPTION
### TL;DR
Updated commission chart to use `or_date` instead of `created_at` for date filtering and display.

### What changed?
- Modified commission chart query to select `or_date` instead of `created_at`
- Updated chart data processing to filter based on `or_date`
- Added null check for `or_date` in data processing
- Modified seed data to generate random `or_date` values within the last year

### How to test?
1. Run database migrations and seed data
2. Navigate to the commission chart view
3. Verify that commission data is displayed correctly based on OR dates
4. Confirm that the chart shows data for the last 12 months

### Why make this change?
The commission chart should reflect data based on when the Official Receipt (OR) was issued rather than when the record was created in the system, providing more accurate financial reporting.