### PR TITLE
TIM-747 Add approval tracking columns to pending export requests

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-sheet.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-sheet.tsx
@@ -12,8 +12,10 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import AccountDownloadsButton from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button'
 import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
+import { createBrowserClient } from '@/utils/supabase'
 
 const AccountDownloadsSheet = () => {
+  const supabase = createBrowserClient()
   const { file, setFile } = useDownloadsContext()
   return (
     <Sheet open={!!file} onOpenChange={() => setFile(null)}>

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -971,6 +971,8 @@ export type Database = {
       pending_export_requests: {
         Row: {
           account_id: string | null
+          approved_at: string | null
+          approved_by: string | null
           created_at: string
           created_by: string
           data: Json | null
@@ -982,6 +984,8 @@ export type Database = {
         }
         Insert: {
           account_id?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
           created_at?: string
           created_by?: string
           data?: Json | null
@@ -993,6 +997,8 @@ export type Database = {
         }
         Update: {
           account_id?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
           created_at?: string
           created_by?: string
           data?: Json | null
@@ -1009,6 +1015,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: 'accounts'
             referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'pending_export_requests_approved_by_fkey'
+            columns: ['approved_by']
+            isOneToOne: false
+            referencedRelation: 'user_profiles'
+            referencedColumns: ['user_id']
           },
           {
             foreignKeyName: 'pending_export_requests_created_by_fkey'

--- a/supabase/migrations/20241117122414_add_approved_by_and_approved_at_columns_and_remove_default_value_on_created_by.sql
+++ b/supabase/migrations/20241117122414_add_approved_by_and_approved_at_columns_and_remove_default_value_on_created_by.sql
@@ -1,0 +1,11 @@
+alter table "public"."pending_export_requests" add column "approved_at" timestamp with time zone;
+
+alter table "public"."pending_export_requests" add column "approved_by" uuid;
+
+alter table "public"."pending_export_requests" alter column "created_by" set default auth.uid();
+
+alter table "public"."pending_export_requests" add constraint "pending_export_requests_approved_by_fkey" FOREIGN KEY (approved_by) REFERENCES user_profiles(user_id) not valid;
+
+alter table "public"."pending_export_requests" validate constraint "pending_export_requests_approved_by_fkey";
+
+


### PR DESCRIPTION
### TL;DR
Added approval tracking fields to pending export requests and initialized Supabase client in downloads sheet.

### What changed?
- Added `approved_at` and `approved_by` columns to `pending_export_requests` table
- Created foreign key relationship between `approved_by` and `user_profiles.user_id`
- Set default value for `created_by` to `auth.uid()`
- Initialized Supabase browser client in AccountDownloadsSheet component

### How to test?
1. Create a new pending export request
2. Verify the `created_by` field is automatically populated
3. Approve a request and confirm both `approved_at` and `approved_by` fields are populated
4. Check that the foreign key relationship works by querying related user profile data

### Why make this change?
To track who approves export requests and when they were approved, providing better audit trails and accountability in the export request workflow.