### PR TITLE
TIM-760 Change mutation when approving requests

### DIFF
--- a/src/app/(dashboard)/admin/approval-request/components/export-requests-approval-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/components/export-requests-approval-button.tsx
@@ -45,8 +45,17 @@ const ExportRequestsApprovalButton: FC<
   )
 
   const handleApproval = async () => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
     if (action === 'approve') {
-      await mutateAsync({ id: exportId, is_approved: true })
+      await mutateAsync({
+        id: exportId,
+        is_approved: true,
+        approved_by: user?.id,
+        approved_at: new Date().toISOString(),
+      })
     } else {
       await mutateAsync({ id: exportId, is_approved: false, is_active: false })
     }


### PR DESCRIPTION
### TL;DR

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vJGCtZypD2dCSpqs2VMi/0f86afea-f2ea-4861-ace4-4a60fcec17be.png)

Added user tracking information when approving export requests.

### What changed?
When approving an export request, the system now captures the approver's ID and timestamp alongside the approval status.

### How to test?
1. Log in as an admin user
2. Navigate to the export requests approval page
3. Approve an export request
4. Verify in the database that the `approved_by` and `approved_at` fields are populated with the current user's ID and timestamp

### Why make this change?
To maintain an audit trail of who approved export requests and when they were approved, enhancing accountability and traceability in the system.