### PR TITLE
TIM-761 Add approval details to downloads sheet

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-sheet.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-sheet.tsx
@@ -12,11 +12,11 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import AccountDownloadsButton from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button'
 import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
-import { createBrowserClient } from '@/utils/supabase'
+import { formatDate } from 'date-fns'
 
 const AccountDownloadsSheet = () => {
-  const supabase = createBrowserClient()
   const { file, setFile } = useDownloadsContext()
+
   return (
     <Sheet open={!!file} onOpenChange={() => setFile(null)}>
       <SheetContent className="xs:w-screen flex w-screen flex-col justify-between overflow-auto bg-card sm:max-w-none md:max-w-md">
@@ -49,20 +49,24 @@ const AccountDownloadsSheet = () => {
               <span className="text-sm font-medium text-[#64748b]">
                 Approved at
               </span>
-              <span className="text-sm text-[#1e293b]">November 15, 2024</span>
+              <span className="text-sm text-[#1e293b]">
+                {file?.approved_at ? formatDate(file.approved_at, 'PPpp') : '-'}
+              </span>
             </div>
             <Separator />
             <div className=" flex flex-row justify-between pb-1 pt-1 ">
               <span className="text-sm font-medium text-[#64748b]">
                 Approved by
               </span>
-              <span className="text-sm text-[#1e293b]">Jane Doe</span>
+              <span className="text-sm text-[#1e293b]">
+                {(file?.approved_by as any)?.first_name}{' '}
+                {(file?.approved_by as any)?.last_name}
+              </span>
             </div>
             <Separator />
           </div>
         </div>
         <SheetFooter className="mt-auto flex flex-row items-center justify-between gap-4 p-12">
-          {/*  TODO : Buttons functionality */}
           <AccountDownloadsButton />
         </SheetFooter>
       </SheetContent>

--- a/src/queries/get-approved-exports.ts
+++ b/src/queries/get-approved-exports.ts
@@ -7,7 +7,7 @@ const getApprovedExports = (
   return supabase
     .from('pending_export_requests')
     .select(
-      `id, export_type, created_at, created_by(first_name, last_name, user_id), account_id(company_name)`,
+      `id, export_type, created_at, created_by(first_name, last_name, user_id), account_id(company_name), approved_by(first_name, last_name, user_id), approved_at`,
       {
         count: 'exact',
       },


### PR DESCRIPTION
### TL;DR

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/vJGCtZypD2dCSpqs2VMi/c5653711-c812-45f7-9969-8cfbdf438508.png)

Added approved_at date formatting and approver details to the downloads sheet

### What changed?
- Removed unused Supabase client import
- Added date formatting for the approved_at timestamp
- Displayed approver's first and last name in the downloads sheet
- Extended the database query to include approved_by and approved_at fields
- Removed TODO comment for button functionality

### How to test?
1. Navigate to the file manager
2. Open the downloads sheet for an approved file
3. Verify the approved_at date is properly formatted
4. Confirm the approver's full name is displayed correctly

### Why make this change?
To provide users with accurate information about when files were approved and who approved them, improving transparency and traceability in the file management system.