### PR TITLE
TIM-762 feat(export): add export employee function

### DIFF
--- a/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
+++ b/src/app/(dashboard)/(home)/(dashboard)/commission/commission-chart.tsx
@@ -32,8 +32,6 @@ const CommissionChart = () => {
       .gte('created_at', subMonths(startOfMonth(new Date()), 12).toISOString()),
   )
 
-  console.log(data)
-
   const processedData = useMemo(() => processChartData(data), [data])
 
   return (

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
@@ -84,7 +84,6 @@ const EmployeeExportModal: FC<EmployeeExportModalProps> = ({
     const {
       data: { user },
     } = await supabase.auth.getUser()
-    console.log(accountId)
     await mutateAsync([
       {
         export_type: exportData,

--- a/src/app/(dashboard)/(home)/file-manager/export/employees-export.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/export/employees-export.tsx
@@ -15,23 +15,50 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { useToast } from '@/components/ui/use-toast'
 import getAllAccounts from '@/queries/get-all-accounts'
+import { Enums } from '@/types/database.types'
 import { createBrowserClient } from '@/utils/supabase'
 import { cn } from '@/utils/tailwind'
-import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import {
+  useInsertMutation,
+  useQuery,
+} from '@supabase-cache-helpers/postgrest-react-query'
 import { Check, ChevronsUpDown } from 'lucide-react'
 import { useState } from 'react'
 
 const EmployeesExport = () => {
+  const { toast } = useToast()
   const [open, setOpen] = useState(false)
   const [value, setValue] = useState('')
 
   const supabase = createBrowserClient()
   const { data: accounts } = useQuery(getAllAccounts(supabase))
 
-  const handleExport = () => {
-    // TODO: Implement export
-  }
+  const { mutateAsync } = useInsertMutation(
+    // @ts-ignore
+    supabase.from('pending_export_requests'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        setOpen(false)
+        toast({
+          title: 'Export Request Submitted',
+          variant: 'default',
+          description:
+            'Your export request has been submitted and is waiting for approval',
+        })
+      },
+      onError: (error) => {
+        toast({
+          title: 'Something went wrong',
+          variant: 'destructive',
+          description: error.message,
+        })
+      },
+    },
+  )
 
   return (
     <div className="flex flex-col gap-10">
@@ -90,7 +117,18 @@ const EmployeesExport = () => {
       </Popover>
 
       <div className="flex justify-end gap-2">
-        <Button onClick={handleExport}>Request Export</Button>
+        <Button
+          onClick={() =>
+            mutateAsync([
+              {
+                account_id: value,
+                export_type: 'employees' as Enums<'export_type'>,
+              },
+            ])
+          }
+        >
+          Request Export
+        </Button>
         <DialogClose asChild>
           <Button variant="outline">Cancel</Button>
         </DialogClose>


### PR DESCRIPTION
### TL;DR
Removed console.log statements and implemented employee export functionality

### What changed?
- Removed debug console.log statements from commission chart and employee export modal
- Added export request functionality to the employees export component
- Implemented toast notifications for successful and failed export requests
- Added mutation handling for submitting export requests

### How to test?
1. Navigate to the file manager
2. Select an account from the dropdown
3. Click "Request Export"
4. Verify that a success toast appears
5. Verify that the export request is created in the pending_export_requests table

### Why make this change?
To clean up debugging code and implement the missing employee export functionality, providing users with the ability to request employee data exports while receiving appropriate feedback on the request status.