### PR TITLE
feat(export): add accounts export functionality

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/export/accounts-export.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/export/accounts-export.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+import { Enums } from '@/types/database.types'
+import { createBrowserClient } from '@/utils/supabase'
+import { useInsertMutation } from '@supabase-cache-helpers/postgrest-react-query'
+import { Loader2 } from 'lucide-react'
+import React from 'react'
+
+interface AccountsExportProps {
+  onClose: () => void
+}
+
+const AccountsExport = ({ onClose }: AccountsExportProps) => {
+  const { toast } = useToast()
+  const supabase = createBrowserClient()
+  const { mutateAsync, isPending } = useInsertMutation(
+    // @ts-ignore
+    supabase.from('pending_export_requests'),
+    ['id'],
+    null,
+    {
+      onSuccess: () => {
+        onClose()
+        toast({
+          title: 'Export request sent',
+          description:
+            'Your export request has been submitted and is waiting for approval.',
+        })
+      },
+      onError: (error) => {
+        toast({
+          title: 'Something went wrong',
+          description: error.message,
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+
+  return (
+    <Button
+      className="mt-4"
+      disabled={isPending}
+      onClick={() =>
+        mutateAsync([
+          {
+            export_type: 'accounts' as Enums<'export_type'>,
+          },
+        ])
+      }
+    >
+      {isPending ? <Loader2 className="animate-spin" /> : 'Export Accounts'}
+    </Button>
+  )
+}
+
+export default AccountsExport

--- a/src/app/(dashboard)/(home)/file-manager/export/export-modal.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/export/export-modal.tsx
@@ -12,6 +12,10 @@ const EmployeesExport = dynamic(() => import('./employees-export'), {
   ssr: false,
 })
 
+const AccountsExport = dynamic(() => import('./accounts-export'), {
+  ssr: false,
+})
+
 interface ExportModalProps {
   exportType: 'employees' | 'accounts' | null
   onClose: () => void
@@ -23,10 +27,15 @@ const ExportModal = ({ onClose, exportType }: ExportModalProps) => {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Export {exportType}</DialogTitle>
-          <DialogDescription>Select an account to export</DialogDescription>
+          <DialogDescription>
+            {exportType === 'employees'
+              ? 'Select an account to export'
+              : 'Confirm export request'}
+          </DialogDescription>
         </DialogHeader>
         <Suspense fallback={<div>Loading...</div>}>
           {exportType === 'employees' && <EmployeesExport onClose={onClose} />}
+          {exportType === 'accounts' && <AccountsExport onClose={onClose} />}
         </Suspense>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
### TL;DR
Added accounts export functionality to the file manager export modal

### What changed?
- Created a new `AccountsExport` component with export request functionality
- Updated `ExportModal` to handle accounts export type
- Added dynamic loading for the accounts export component
- Modified dialog description to be context-aware based on export type

### How to test?
1. Navigate to the file manager
2. Click on export accounts
3. Verify the export modal appears with the correct description
4. Click "Export Accounts" button
5. Confirm the success toast appears with the export request message
6. Verify the modal closes after submission

### Why make this change?
To provide users with the ability to export account data through a pending request system, ensuring proper approval workflow for sensitive account information exports