### PR TITLE
TIM-772 Add employee data to export requests

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
@@ -84,11 +84,33 @@ const EmployeeExportModal: FC<EmployeeExportModalProps> = ({
     const {
       data: { user },
     } = await supabase.auth.getUser()
+
+    const { data: oldEmployeesData } = await supabase
+      .from('company_employees')
+      .select('*')
+      .eq('is_active', true)
+      .eq('account_id', accountId)
+
+    if (!oldEmployeesData || oldEmployeesData.length === 0) {
+      toast({
+        title: 'No employees data found',
+        variant: 'destructive',
+        description: 'No employees data found to export',
+      })
+      return
+    }
+
+    const employeesData = oldEmployeesData.map((employee) => {
+      const { id, account_id, ...rest } = employee
+      return rest
+    })
+
     await mutateAsync([
       {
         export_type: exportData,
         created_by: user?.id,
         account_id: accountId,
+        data: employeesData,
       },
     ])
   }


### PR DESCRIPTION
### TL;DR
Added employee data validation and mapping before export request creation

### What changed?
- Added validation to check if active employees exist before creating an export request
- Added error toast notification when no employee data is found
- Mapped employee data to exclude `id` and `account_id` fields from the export
- Included the processed employee data in the export request mutation

### How to test?
1. Navigate to the employee export modal
2. Try to create an export request with no active employees
3. Verify error toast appears
4. Add active employees and create an export request
5. Verify the export request contains the mapped employee data

### Why make this change?
To prevent creation of empty export requests and ensure only relevant employee data is included in the export. This improves data quality and user experience by providing immediate feedback when no data is available for export.