### PR TITLE
feat(file-manager): add server-side data prefetching

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/page.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/page.tsx
@@ -1,14 +1,27 @@
+'use server'
 import React from 'react'
 import { DownloadsProvider } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 import AccountDownloads from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads'
 import DownloadsPageTitle from '@/app/(dashboard)/(home)/file-manager/downloads-page-title'
 import EmployeeDownloads from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads'
 import DownloadsSheet from '@/app/(dashboard)/(home)/file-manager/downloads-sheet'
-import CompanyProvider from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-provider'
+import { createServerClient } from '@/utils/supabase'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
+import { cookies } from 'next/headers'
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query'
+import getApprovedExports from '@/queries/get-approved-exports'
 
-const Page = () => {
+const FileManagerPage = async () => {
+  const supabase = createServerClient(cookies())
+  const queryClient = new QueryClient()
+  await prefetchQuery(queryClient, getApprovedExports(supabase))
+
   return (
-    <>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <DownloadsProvider>
         <div className="flex flex-col">
           <DownloadsPageTitle />
@@ -23,8 +36,8 @@ const Page = () => {
         </div>
         <DownloadsSheet />
       </DownloadsProvider>
-    </>
+    </HydrationBoundary>
   )
 }
 
-export default Page
+export default FileManagerPage


### PR DESCRIPTION
### TL;DR
Added server-side data prefetching for the File Manager page using React Query hydration.

### What changed?
- Converted the page component to a server component with 'use server'
- Implemented server-side data prefetching for approved exports using Supabase
- Added React Query hydration boundary to maintain data consistency
- Renamed the component from `Page` to `FileManagerPage` for better clarity

### How to test?
1. Navigate to the File Manager page
2. Verify that approved exports data loads immediately without loading states
3. Confirm that the data remains consistent during client-side navigation
4. Check that all file manager functionality continues to work as expected

### Why make this change?
This optimization improves the initial page load performance by prefetching necessary data on the server. It eliminates the need for client-side data fetching on first load, reducing loading states and providing a smoother user experience.