### PR TITLE
feat(export): refactor accounts export functionality

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button'
 const AccountDownloadsButton = () => {
   return (
     <>
-      <Button className="w-full">Export File</Button>
       <Button variant="outline" className="w-full">
         Cancel
       </Button>

--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-file-item.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-file-item.tsx
@@ -24,7 +24,7 @@ const AccountDownloadsFileItem: FC<AccountDownloadsFileItemProps> = ({
         </div>
       </div>
       <span className="text-center text-xs font-medium text-[#1e293b]">
-        {new Date(data.created_at).toLocaleDateString()} - Account Sheet
+        {new Date(data.created_at).toLocaleDateString()} - Accounts Sheet
       </span>
     </div>
   )

--- a/src/app/(dashboard)/(home)/file-manager/downloads-sheet.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloads-sheet.tsx
@@ -14,6 +14,7 @@ import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downl
 import EmployeeDownloadsButton from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-button'
 import { formatDate } from 'date-fns'
 import AccountDownloadsButton from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-button'
+import ExportAccounts from '@/app/(dashboard)/(home)/accounts/export-requests/export-accounts'
 
 const DownloadsSheet = () => {
   const { file, setFile } = useDownloadsContext()
@@ -84,7 +85,10 @@ const DownloadsSheet = () => {
         </div>
         <SheetFooter className="mt-auto flex flex-row items-center justify-between gap-4 p-12">
           {file?.export_type === 'accounts' ? (
-            <AccountDownloadsButton />
+            <>
+              <ExportAccounts id={file.id} />
+              <AccountDownloadsButton />
+            </>
           ) : (
             <EmployeeDownloadsButton />
           )}


### PR DESCRIPTION
### TL;DR
Enhanced the account export functionality to handle approved export requests and streamlined the export process.

### What changed?
- Modified the export accounts modal to use React Query for data fetching
- Removed unnecessary fields (id, created_at, updated_at) from exported data
- Updated the export accounts component to handle approved export requests
- Added export functionality to the downloads sheet
- Integrated export button with the file manager interface

### How to test?
1. Navigate to the accounts section
2. Create a new export request
3. Approve the export request
4. Go to the file manager
5. Select an approved account export
6. Click "Export File" to download the XLSX file
7. Verify the exported file contains the correct account data without system fields

### Why make this change?
To improve the security and control of the export process by requiring approval before allowing data exports, while also ensuring sensitive system fields are excluded from the exported data. This change provides a more organized and secure way to handle account data exports.