### PR TITLE
feat(export): add disabled state and tooltip for unapproved files

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-file-item.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads-file-item.tsx
@@ -2,6 +2,12 @@ import React, { FC } from 'react'
 import { File } from 'lucide-react'
 import { Tables } from '@/types/database.types'
 import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
+import { cn } from '@/utils/tailwind'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface AccountDownloadsFileItemProps {
   data: Tables<'pending_export_requests'>
@@ -11,22 +17,33 @@ const AccountDownloadsFileItem: FC<AccountDownloadsFileItemProps> = ({
   data,
 }) => {
   const { setFile } = useDownloadsContext()
+  const isDisabled = !data.is_approved
 
   return (
-    <div
-      onClick={() => setFile(data)}
-      className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md hover:cursor-pointer"
-    >
-      <div className="relative">
-        <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
-        <div className=" absolute bottom-0 left-0 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
-          XLS
+    <Tooltip>
+      {isDisabled && (
+        <TooltipContent>This file is not approved yet</TooltipContent>
+      )}
+      <TooltipTrigger>
+        <div
+          onClick={() => !isDisabled && setFile(data)}
+          className={cn(
+            isDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+            'flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md',
+          )}
+        >
+          <div className="relative">
+            <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
+            <div className=" absolute bottom-0 left-0 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+              XLS
+            </div>
+          </div>
+          <span className="text-center text-xs font-medium text-[#1e293b]">
+            {new Date(data.created_at).toLocaleDateString()} - Account Sheet
+          </span>
         </div>
-      </div>
-      <span className="text-center text-xs font-medium text-[#1e293b]">
-        {new Date(data.created_at).toLocaleDateString()} - Accounts Sheet
-      </span>
-    </div>
+      </TooltipTrigger>
+    </Tooltip>
   )
 }
 

--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import AccountDownloadsFileItem from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads-file-item'
-import getApprovedExports from '@/queries/get-approved-exports'
+import getExports from '@/queries/get-approved-exports'
 
 const AccountDownloads = () => {
   const supabase = createBrowserClient()
 
-  const { data } = useQuery(getApprovedExports(supabase, 'asc'))
+  const { data } = useQuery(getExports(supabase, 'asc'))
   const accounts = data?.filter((item) => item.export_type === 'accounts')
 
   return (

--- a/src/app/(dashboard)/(home)/file-manager/downloads-page-title.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloads-page-title.tsx
@@ -6,14 +6,14 @@ import {
   PageTitle,
 } from '@/components/page-header'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import getApprovedExports from '@/queries/get-approved-exports'
+import getExports from '@/queries/get-approved-exports'
 import { createBrowserClient } from '@/utils/supabase'
 import { Skeleton } from '@/components/ui/skeleton'
 import ExportButton from '@/app/(dashboard)/(home)/file-manager/export/export-button'
 
 const DownloadsPageTitle = () => {
   const supabase = createBrowserClient()
-  const { count, isPending } = useQuery(getApprovedExports(supabase))
+  const { count, isPending } = useQuery(getExports(supabase))
 
   return (
     <PageHeader>

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-file-item.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-file-item.tsx
@@ -2,6 +2,12 @@ import React, { FC } from 'react'
 import { Tables } from '@/types/database.types'
 import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 import { File } from 'lucide-react'
+import { cn } from '@/utils/tailwind'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 interface EmployeeDownloadsFileItemProps {
   data: Tables<'pending_export_requests'>
@@ -11,22 +17,33 @@ const EmployeeDownloadsFileItem: FC<EmployeeDownloadsFileItemProps> = ({
   data,
 }) => {
   const { setFile } = useDownloadsContext()
+  const isDisabled = !data.is_approved
 
   return (
-    <div
-      onClick={() => setFile(data)}
-      className="flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md hover:cursor-pointer"
-    >
-      <div className="relative">
-        <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
-        <div className=" absolute bottom-0 left-0 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
-          XLS
+    <Tooltip>
+      {isDisabled && (
+        <TooltipContent>This file is not approved yet</TooltipContent>
+      )}
+      <TooltipTrigger>
+        <div
+          onClick={() => !isDisabled && setFile(data)}
+          className={cn(
+            isDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+            'flex h-40 w-40 flex-col items-center justify-center gap-4 rounded-2xl bg-card p-4 drop-shadow-md',
+          )}
+        >
+          <div className="relative">
+            <File className="h-20 w-20 fill-[#94a3b8] text-[#FCFCFC]" />
+            <div className=" absolute bottom-0 left-0 h-5 w-9 rounded-md bg-green-600 py-0.5 text-center text-xs font-semibold text-white">
+              XLS
+            </div>
+          </div>
+          <span className="text-center text-xs font-medium text-[#1e293b]">
+            {(data.account_id as any).company_name} - Employee Sheet
+          </span>
         </div>
-      </div>
-      <span className="text-center text-xs font-medium text-[#1e293b]">
-        {(data.account_id as any).company_name} - Employee Sheet
-      </span>
-    </div>
+      </TooltipTrigger>
+    </Tooltip>
   )
 }
 

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import EmployeeDownloadsFileItem from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads-file-item'
-import getApprovedExports from '@/queries/get-approved-exports'
+import getExports from '@/queries/get-approved-exports'
 
 const EmployeeDownloads = () => {
   const supabase = createBrowserClient()
 
-  const { data } = useQuery(getApprovedExports(supabase, 'asc'))
+  const { data } = useQuery(getExports(supabase, 'asc'))
   const employees = data?.filter((item) => item.export_type === 'employees')
 
   return (

--- a/src/app/(dashboard)/(home)/file-manager/export/export-button.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/export/export-button.tsx
@@ -27,16 +27,16 @@ const ExportButton = () => {
           <DropdownMenuLabel>New Export</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            onClick={() => setExportType('employees')}
-            className="cursor-pointer"
-          >
-            Employees
-          </DropdownMenuItem>
-          <DropdownMenuItem
             onClick={() => setExportType('accounts')}
             className="cursor-pointer"
           >
             Accounts
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setExportType('employees')}
+            className="cursor-pointer"
+          >
+            Employees
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/app/(dashboard)/(home)/file-manager/page.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/page.tsx
@@ -13,12 +13,12 @@ import {
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query'
-import getApprovedExports from '@/queries/get-approved-exports'
+import getExports from '@/queries/get-approved-exports'
 
 const FileManagerPage = async () => {
   const supabase = createServerClient(cookies())
   const queryClient = new QueryClient()
-  await prefetchQuery(queryClient, getApprovedExports(supabase))
+  await prefetchQuery(queryClient, getExports(supabase))
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/queries/get-approved-exports.ts
+++ b/src/queries/get-approved-exports.ts
@@ -1,21 +1,29 @@
 import { TypedSupabaseClient } from '@/types/typedSupabaseClient'
 
-const getApprovedExports = (
+const getExports = (
   supabase: TypedSupabaseClient,
   sort: 'asc' | 'desc' = 'desc',
 ) => {
   return supabase
     .from('pending_export_requests')
     .select(
-      `id, export_type, created_at, created_by(first_name, last_name, user_id), account_id(company_name), approved_by(first_name, last_name, user_id), approved_at`,
+      `
+      id,
+      export_type,
+      created_at,
+      created_by(first_name, last_name, user_id),
+      account_id(company_name),
+      approved_by(first_name, last_name, user_id),
+      approved_at,
+      is_approved
+      `,
       {
         count: 'exact',
       },
     )
-    .eq('is_approved', true)
     .eq('is_active', true)
     .order('created_at', { ascending: sort === 'asc' })
     .throwOnError()
 }
 
-export default getApprovedExports
+export default getExports


### PR DESCRIPTION
### TL;DR
Added support for displaying unapproved export files with visual indicators and tooltips.

### What changed?
- Added visual state for unapproved files (opacity reduced and cursor disabled)
- Implemented tooltips to indicate when files are not approved
- Modified query to fetch all export files instead of only approved ones
- Reordered export dropdown menu items (Accounts now appears before Employees)

### How to test?
1. Navigate to the file manager
2. Verify that unapproved files appear with reduced opacity
3. Hover over an unapproved file to see the "not approved" tooltip
4. Confirm that unapproved files cannot be clicked/selected
5. Check that the export dropdown shows "Accounts" before "Employees"

### Why make this change?
To improve user experience by showing all export files while clearly indicating their approval status, rather than hiding unapproved files completely. This provides better visibility into the export process and helps users understand why certain files may not be immediately accessible.