### PR TITLE
feat(downloads): improve file grid layout responsiveness

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/account-files/account-downloads.tsx
@@ -12,7 +12,7 @@ const AccountDownloads = () => {
   const accounts = data?.filter((item) => item.export_type === 'accounts')
 
   return (
-    <div className="flex flex-row gap-6">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] place-items-center justify-items-center gap-6">
       {accounts?.map((exportFiles) => (
         <AccountDownloadsFileItem
           key={exportFiles.id}

--- a/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads.tsx
@@ -12,7 +12,7 @@ const EmployeeDownloads = () => {
   const employees = data?.filter((item) => item.export_type === 'employees')
 
   return (
-    <div className="flex flex-row gap-6">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] place-items-center justify-items-center gap-6">
       {employees?.map((exportFiles) => (
         <EmployeeDownloadsFileItem
           data={exportFiles as any}


### PR DESCRIPTION
### TL;DR
Updated the file manager's grid layout to create a responsive, auto-filling grid for both account and employee downloads.

### What changed?
Replaced the flex row layout with a responsive grid layout in both `account-downloads.tsx` and `employee-downloads.tsx`. The new grid system automatically adjusts columns based on available space, with each column having a minimum width of 10rem.

### How to test?
1. Navigate to the file manager section
2. Check both account and employee download sections
3. Verify that files arrange in a grid pattern
4. Resize browser window to confirm responsive behavior
5. Ensure files remain centered and properly spaced

### Why make this change?
The previous flex row layout didn't efficiently use space or handle different screen sizes well. The new grid layout provides better organization of files, improved responsiveness, and a more consistent visual presentation across different screen sizes.