### PR TITLE
TIM-783 feat(export): remove additional fields from employee export data

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal.tsx
@@ -101,7 +101,15 @@ const EmployeeExportModal: FC<EmployeeExportModalProps> = ({
     }
 
     const employeesData = oldEmployeesData.map((employee) => {
-      const { id, account_id, ...rest } = employee
+      const {
+        id,
+        account_id,
+        is_active,
+        created_at,
+        created_by,
+        updated_at,
+        ...rest
+      } = employee
       return rest
     })
 


### PR DESCRIPTION
### TL;DR
Removed additional system fields from employee export data

### What changed?
Updated the employee export modal to exclude internal system fields (`is_active`, `created_at`, `created_by`, `updated_at`) from the exported employee data, in addition to the previously excluded `id` and `account_id` fields.

### How to test?
1. Navigate to the employee export modal
2. Select employees to export
3. Generate an export
4. Verify that the exported data does not contain the following fields:
   - id
   - account_id
   - is_active
   - created_at
   - created_by
   - updated_at

### Why make this change?
To provide cleaner, more relevant data in employee exports by removing internal system fields that aren't meaningful to end users.