### PR TITLE
TIM-786 Fix: Close sheet when file is deleted

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/downloads-delete-button.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/downloads-delete-button.tsx
@@ -19,7 +19,7 @@ import { useDownloadsContext } from '@/app/(dashboard)/(home)/file-manager/downl
 
 const DownloadsDeleteButton = () => {
   const supabase = createBrowserClient()
-  const { file, isSheetOpen, setIsSheetOpen } = useDownloadsContext()
+  const { file, setIsSheetOpen, setFile } = useDownloadsContext()
 
   const { mutateAsync, isPending } = useUpdateMutation(
     // @ts-expect-error
@@ -34,6 +34,7 @@ const DownloadsDeleteButton = () => {
           description: 'Successfully deleted request',
         })
         setIsSheetOpen(false)
+        setFile(null)
       },
       onError: (err: any) => {
         toast({


### PR DESCRIPTION
### TL;DR
Added file state reset when deleting downloads

### What changed?
Added `setFile(null)` when successfully deleting a download to ensure the file state is properly cleared

### How to test?
1. Navigate to the downloads section
2. Select a file to delete
3. Click delete and confirm the action
4. Verify that the sheet closes and no file remains selected

### Why make this change?
Previously, the file state wasn't being reset after deletion, which could lead to stale state and potential UI inconsistencies. This change ensures a clean state after file deletion.