### PR TITLE
feat(pages): add metadata titles to file manager pages

### DIFF
--- a/src/app/(dashboard)/(home)/file-manager/page.tsx
+++ b/src/app/(dashboard)/(home)/file-manager/page.tsx
@@ -1,24 +1,30 @@
 'use server'
-import React from 'react'
-import { DownloadsProvider } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 import AccountDownloads from '@/app/(dashboard)/(home)/file-manager/account-files/account-downloads'
 import DownloadsPageTitle from '@/app/(dashboard)/(home)/file-manager/downloads-page-title'
+import { DownloadsProvider } from '@/app/(dashboard)/(home)/file-manager/downloads-provider'
 import EmployeeDownloads from '@/app/(dashboard)/(home)/file-manager/employee-files/employee-downloads'
+import getExports from '@/queries/get-approved-exports'
 import { createServerClient } from '@/utils/supabase'
 import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import { cookies } from 'next/headers'
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query'
-import getExports from '@/queries/get-approved-exports'
+import { Metadata } from 'next'
 import dynamic from 'next/dynamic'
+import { cookies } from 'next/headers'
 
 const DownloadsSheet = dynamic(
   () => import('@/app/(dashboard)/(home)/file-manager/downloads-sheet'),
   { ssr: false },
 )
+
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'File Manager',
+  }
+}
 
 const FileManagerPage = async () => {
   const supabase = createServerClient(cookies())

--- a/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/account-exports/page.tsx
@@ -1,16 +1,22 @@
-import React from 'react'
+import AccountExportRequestModal from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal'
+import { AccountExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
 import AccountExportRequestsTable from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-table'
+import getPendingAccountExports from '@/queries/get-pending-account-exports'
+import { createServerClient } from '@/utils/supabase'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import {
   HydrationBoundary,
   QueryClient,
   dehydrate,
 } from '@tanstack/react-query'
-import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import getPendingAccountExports from '@/queries/get-pending-account-exports'
-import { createServerClient } from '@/utils/supabase'
+import { Metadata } from 'next'
 import { cookies } from 'next/headers'
-import AccountExportRequestModal from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-request-modal'
-import { AccountExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/account-exports/account-export-requests-provider'
+
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Account Export Requests',
+  }
+}
 
 const ExportRequestPage = async () => {
   const supabase = createServerClient(cookies())

--- a/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
+++ b/src/app/(dashboard)/admin/approval-request/employee-exports/page.tsx
@@ -1,16 +1,21 @@
-import React from 'react'
+import EmployeeExportRequestsModal from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal'
+import { EmployeeExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
 import EmployeeExportsRequestsTable from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-exports-requests-table'
+import getAllPendingEmployeeExports from '@/queries/get-all-pending-employee-exports'
 import { createServerClient } from '@/utils/supabase'
+import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query'
-import { prefetchQuery } from '@supabase-cache-helpers/postgrest-react-query'
-import getAllPendingEmployeeExports from '@/queries/get-all-pending-employee-exports'
+import { Metadata } from 'next'
 import { cookies } from 'next/headers'
-import EmployeeExportRequestsModal from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-modal'
-import { EmployeeExportRequestsProvider } from '@/app/(dashboard)/admin/approval-request/employee-exports/employee-export-requests-provider'
+export const metadata = async (): Promise<Metadata> => {
+  return {
+    title: 'Employee Export Requests',
+  }
+}
 
 const Page = async () => {
   const supabase = createServerClient(cookies())


### PR DESCRIPTION
### TL;DR
Added page titles to File Manager and Export Request pages

### What changed?
- Added metadata export with page titles for:
  - File Manager page
  - Account Export Requests page
  - Employee Export Requests page
- Reorganized imports for better code organization

### How to test?
1. Navigate to the File Manager page and verify the browser tab shows "File Manager"
2. Visit the Account Export Requests page and confirm the title shows "Account Export Requests"
3. Check the Employee Export Requests page and ensure the title displays "Employee Export Requests"

### Why make this change?
Improves user experience by providing clear page identification in browser tabs, making it easier for users to navigate between multiple open tabs and understand their current location in the application.