### PR TITLE
feat(import): add member type and expiration fields

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/fields.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/import/fields.ts
@@ -18,7 +18,7 @@ const importFields = [
       type: 'input',
     },
     // Used in the first step to provide an example of what data is expected in this field. Optional.
-    example: 'Francisco, Jeremy',
+    example: 'Francisco, Monds',
     // Can have multiple validations that are visible in Validation Step table.
   },
   {
@@ -28,7 +28,7 @@ const importFields = [
     fieldType: {
       type: 'input',
     },
-    example: 'Troy',
+    example: 'Monds',
     validations: [
       {
         rule: 'required',
@@ -44,7 +44,7 @@ const importFields = [
     fieldType: {
       type: 'input',
     },
-    example: 'Baker',
+    example: 'Francisco',
     validations: [
       {
         rule: 'required',
@@ -176,6 +176,62 @@ const importFields = [
       type: 'input',
     },
     example: 'MBL 10000',
+  },
+  {
+    label: 'Member Type',
+    key: 'member_type',
+    alternateMatches: ['member type', 'member', 'member_type', 'MEMBER TYPE'],
+    fieldType: {
+      type: 'select',
+      options: [
+        {
+          label: 'Principal',
+          value: 'principal',
+          alternateMatches: ['principal', 'PRINCIPAL', 'P'],
+        },
+        {
+          label: 'Dependent',
+          value: 'dependent',
+          alternateMatches: ['dependent', 'DEPENDENT', 'D'],
+        },
+      ],
+    },
+    example: 'principal',
+  },
+  {
+    label: 'Dependent Relation',
+    key: 'dependent_relation',
+    alternateMatches: ['dependent relation', 'dependent', 'dependent_relation'],
+    fieldType: {
+      type: 'select',
+      options: [
+        {
+          label: 'Spouse',
+          value: 'spouse',
+          alternateMatches: ['spouse', 'SPOUSE', 'S'],
+        },
+        {
+          label: 'Child',
+          value: 'child',
+          alternateMatches: ['child', 'CHILD', 'C'],
+        },
+        {
+          label: 'Parent',
+          value: 'parent',
+          alternateMatches: ['parent', 'PARENT', 'P'],
+        },
+      ],
+    },
+    example: 'spouse',
+  },
+  {
+    label: 'Expiration Date',
+    key: 'expiration_date',
+    alternateMatches: ['expiration date', 'expiration', 'expiration_date'],
+    fieldType: {
+      type: 'input',
+    },
+    example: '1/25/2024',
   },
 ]
 


### PR DESCRIPTION
### TL;DR
Added member type, dependent relation, and expiration date fields to employee import functionality and updated example values.

### What changed?
- Added three new import fields:
  - Member Type (select field with Principal/Dependent options)
  - Dependent Relation (select field with Spouse/Child/Parent options)
  - Expiration Date (input field)
- Updated example values for name fields to use "Francisco, Monds" instead of previous examples

### How to test?
1. Navigate to the employee import feature
2. Upload a CSV file containing member type, dependent relation, and expiration date columns
3. Verify that the new fields are properly mapped during the import process
4. Confirm that both principal and dependent relationships can be imported
5. Validate that expiration dates are correctly processed

### Why make this change?
To support the import of dependent member information and track membership expiration dates, enabling more comprehensive employee data management within the system.