### PR TITLE
feat(employees): add member type and dependent fields

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-actions-dropdown.tsx
@@ -1,6 +1,3 @@
-import DeleteAllEmployees from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/delete-all-employees'
-import EmployeeFormModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form-modal'
-import EmployeeExportModal from '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
 import EllipsisVertical from '@/assets/icons/ellipsis-vertical'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,6 +9,29 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { FileDown, Plus, Trash2 } from 'lucide-react'
+import dynamic from 'next/dynamic'
+
+const EmployeeFormModal = dynamic(
+  () =>
+    import(
+      '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form-modal'
+    ),
+  { ssr: false },
+)
+const EmployeeExportModal = dynamic(
+  () =>
+    import(
+      '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/export-requests/employee-export-modal'
+    ),
+  { ssr: false },
+)
+const DeleteAllEmployees = dynamic(
+  () =>
+    import(
+      '@/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/delete-all-employees'
+    ),
+  { ssr: false },
+)
 
 const EmployeeActionsDropdown = () => {
   return (

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-information/employee-form.tsx
@@ -385,8 +385,182 @@ const EmployeeForm: FC<EmployeeFormProps> = ({
               </FormItem>
             )}
           />
+          <FormField
+            control={form.control}
+            name="member_type"
+            render={({ field }) => (
+              <FormItem className="grid grid-cols-4 items-center gap-x-4 gap-y-0">
+                <FormLabel className="text-right">Member Type</FormLabel>
+                <FormControl className="col-span-3">
+                  <Select
+                    {...field}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending}
+                  >
+                    <SelectTrigger className="col-span-3">
+                      <SelectValue placeholder="Select Member Type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="principal">Principal</SelectItem>
+                      <SelectItem value="dependent">Dependent</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage className="col-span-3 col-start-2" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="dependent_relation"
+            render={({ field }) => (
+              <FormItem className="grid grid-cols-4 items-center gap-x-4 gap-y-0">
+                <FormLabel className="text-right">Dependent Relation</FormLabel>
+                <FormControl className="col-span-3">
+                  <Select
+                    {...field}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isPending}
+                  >
+                    <SelectTrigger className="col-span-3">
+                      <SelectValue placeholder="Select Dependent Relation" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="spouse">Spouse</SelectItem>
+                      <SelectItem value="child">Child</SelectItem>
+                      <SelectItem value="parent">Parent</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage className="col-span-3 col-start-2" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="expiration_date"
+            render={({ field }) => (
+              <FormItem className="grid grid-cols-4 items-center gap-x-4 gap-y-0">
+                <FormLabel className="text-right">Expiration Date</FormLabel>
+                <FormControl className="col-span-3">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant={'outline'}
+                          className={cn(
+                            'col-span-3 flex h-12 w-full rounded-lg border border-input bg-white px-4 py-3 text-sm shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                            !field.value && 'text-muted-foreground',
+                            'text-left font-normal',
+                          )}
+                          disabled={isPending}
+                        >
+                          {field.value ? (
+                            format(field.value, 'PP')
+                          ) : (
+                            <span>Pick a date</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value}
+                        onSelect={field.onChange}
+                        initialFocus
+                        captionLayout="dropdown"
+                        toYear={new Date().getFullYear() + 20}
+                        fromYear={1900}
+                        classNames={{
+                          day_hidden: 'invisible',
+                          dropdown:
+                            'px-2 py-1.5 max-h-[100px] overflow-y-auto rounded-md bg-popover text-popover-foreground text-sm  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background',
+                          caption_dropdowns: 'flex gap-3',
+                          vhidden: 'hidden',
+                          caption_label: 'hidden',
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </FormControl>
+                <FormMessage className="col-span-3 col-start-2" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="cancelation_date"
+            render={({ field }) => (
+              <FormItem className="grid grid-cols-4 items-center gap-x-4 gap-y-0">
+                <FormLabel className="text-right">
+                  Cancelation Effective Date
+                </FormLabel>
+                <FormControl className="col-span-3">
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant={'outline'}
+                          className={cn(
+                            'col-span-3 flex h-12 w-full rounded-lg border border-input bg-white px-4 py-3 text-sm shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                            !field.value && 'text-muted-foreground',
+                            'text-left font-normal',
+                          )}
+                          disabled={isPending}
+                        >
+                          {field.value ? (
+                            format(field.value, 'PP')
+                          ) : (
+                            <span>Pick a date</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value}
+                        onSelect={field.onChange}
+                        initialFocus
+                        captionLayout="dropdown"
+                        toYear={new Date().getFullYear() + 20}
+                        fromYear={1900}
+                        classNames={{
+                          day_hidden: 'invisible',
+                          dropdown:
+                            'px-2 py-1.5 max-h-[100px] overflow-y-auto rounded-md bg-popover text-popover-foreground text-sm  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background',
+                          caption_dropdowns: 'flex gap-3',
+                          vhidden: 'hidden',
+                          caption_label: 'hidden',
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </FormControl>
+                <FormMessage className="col-span-3 col-start-2" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="remarks"
+            render={({ field }) => (
+              <FormItem className="grid grid-cols-4 items-center gap-x-4 gap-y-0">
+                <FormLabel className="text-right">Remarks</FormLabel>
+                <FormControl className="col-span-3">
+                  <Input type="text" {...field} disabled={isPending} />
+                </FormControl>
+                <FormMessage className="col-span-3 col-start-2" />
+              </FormItem>
+            )}
+          />
 
-          <div className="flex justify-end gap-2 pt-2">
+          <div className="col-span-2 flex justify-end gap-2 pt-2">
             <Button
               variant={'outline'}
               type="button"

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema.ts
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(employees)/employee-schema.ts
@@ -10,6 +10,11 @@ const employeeSchema = z.object({
   effective_date: z.date().optional(),
   room_plan: z.string().optional(),
   maximum_benefit_limit: z.string().optional(),
+  member_type: z.enum(['principal', 'dependent']).optional(),
+  dependent_relation: z.enum(['spouse', 'child', 'parent']).optional(),
+  expiration_date: z.date().optional(),
+  cancelation_date: z.date().optional(),
+  remarks: z.string().optional(),
 })
 
 export default employeeSchema

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}


### PR DESCRIPTION
### TL;DR
Added new fields to the employee form including member type, dependent relation, expiration date, cancelation date, and remarks.

### What changed?
- Implemented dynamic imports for employee-related components to improve initial load performance
- Added new form fields:
  - Member Type (principal/dependent dropdown)
  - Dependent Relation (spouse/child/parent dropdown)
  - Expiration Date (calendar picker)
  - Cancelation Effective Date (calendar picker)
  - Remarks (text input)
- Updated employee schema to include new field validations
- Modified select component cursor style from default to pointer

### How to test?
1. Navigate to the employee form
2. Verify all new fields are present and functional:
   - Select different member types
   - Choose dependent relations
   - Set expiration and cancelation dates
   - Add remarks
3. Submit the form and verify data persistence
4. Check that dropdown hover states show pointer cursor

### Why make this change?
To support more detailed employee information management and improve the user experience when handling dependent relationships and membership status tracking.