### PR TITLE
TIM-800 refactor(accounts): department request permissions

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -10,6 +10,7 @@ import percentageOptions from '@/components/maskito/percentage-options'
 import { Button } from '@/components/ui/button'
 import { Form } from '@/components/ui/form'
 import { toast } from '@/components/ui/use-toast'
+import { useUserServer } from '@/providers/UserProvider'
 import getAccountById from '@/queries/get-account-by-id'
 import normalizeToUTC from '@/utils/normalize-to-utc'
 import { createBrowserClient } from '@/utils/supabase'
@@ -18,6 +19,7 @@ import { maskitoTransform } from '@maskito/core'
 import {
   useInsertMutation,
   useQuery,
+  useUpsertMutation,
 } from '@supabase-cache-helpers/postgrest-react-query'
 import { FC, FormEventHandler, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -31,6 +33,7 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
   const { editMode, setEditMode } = useCompanyEditContext()
   const supabase = createBrowserClient()
   const { data: account } = useQuery(getAccountById(supabase, companyId))
+  const { user } = useUserServer()
 
   const form = useForm<z.infer<typeof accountsSchema>>({
     resolver: zodResolver(accountsSchema),
@@ -116,17 +119,26 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
     },
   })
 
-  const { mutateAsync } = useInsertMutation(
+  const { mutateAsync } = useUpsertMutation(
     //@ts-ignore
-    supabase.from('pending_accounts'),
+    supabase.from(
+      user?.user_metadata?.department === 'marketing'
+        ? 'pending_accounts' // marketing needs to insert to pending_accounts instead of accounts
+        : 'accounts',
+    ),
     ['id'],
     null,
     {
       onSuccess: () => {
         toast({
-          title: 'Company details edit request submitted!',
+          title:
+            user?.user_metadata?.department === 'marketing'
+              ? 'Company details edit request submitted!'
+              : 'Company details edited successfully!',
           description:
-            'Your request to edit the company details has been submitted successfully and is awaiting approval.',
+            user?.user_metadata?.department === 'marketing'
+              ? 'Your request to edit the company details has been submitted successfully and is awaiting approval.'
+              : 'Your company details have been edited successfully.',
         })
         setEditMode(false)
       },
@@ -158,7 +170,6 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
 
         await mutateAsync([
           {
-            account_id: companyId,
             company_name: data.company_name,
             company_address: data.company_address,
             initial_head_count: data.initial_head_count,
@@ -210,8 +221,15 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
                     new Date(data.annual_physical_examination_date),
                   )
                 : null,
-            created_by: user.id,
-            operation_type: 'update',
+            ...(user?.user_metadata?.department === 'marketing'
+              ? {
+                  created_by: user.id, // marketing needs to add this since they are inserting to pending_accounts instead of accounts
+                  account_id: companyId,
+                  operation_type: 'update',
+                }
+              : {
+                  id: companyId, // if we're updating, we need to specify the id (not used by marketing dept)
+                }),
           },
         ])
       })(e)

--- a/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import accountsSchema from './accounts-schema'
 import MarketingInputs from './forms/marketing-inputs'
 import normalizeToUTC from '@/utils/normalize-to-utc'
+import { useUserServer } from '@/providers/UserProvider'
 
 interface AddAccountFormProps {
   setIsOpen: (isOpen: boolean) => void
@@ -20,6 +21,7 @@ interface AddAccountFormProps {
 
 const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
   const { toast } = useToast()
+  const { user } = useUserServer()
   const form = useForm<z.infer<typeof accountsSchema>>({
     resolver: zodResolver(accountsSchema),
     defaultValues: {
@@ -62,15 +64,25 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
 
   const { mutateAsync, isPending, isSuccess } = useInsertMutation(
     // @ts-ignore
-    supabase.from('pending_accounts'),
+    supabase.from(
+      // marketing needs to insert to pending_accounts instead of accounts
+      user?.user_metadata?.department === 'marketing'
+        ? 'pending_accounts'
+        : 'accounts',
+    ),
     ['id'],
     null,
     {
       onSuccess: () => {
         toast({
-          title: 'Account creation request submitted!',
+          title:
+            user?.user_metadata?.department === 'marketing'
+              ? 'Account creation request submitted!'
+              : 'Account created successfully!',
           description:
-            'Your request to create a new account has been submitted successfully and is awaiting approval.',
+            user?.user_metadata?.department === 'marketing'
+              ? 'Your request to create a new account has been submitted successfully and is awaiting approval.'
+              : 'Your account has been created successfully.',
         })
 
         form.reset()
@@ -101,7 +113,7 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
           .from('pending_accounts')
           .select('company_name')
           .eq('company_name', data.company_name)
-          .single()
+          .maybeSingle()
 
         if (existingAccount) {
           form.setError('company_name', {
@@ -115,7 +127,7 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
           .from('accounts')
           .select('company_name')
           .eq('company_name', data.company_name)
-          .single()
+          .maybeSingle()
 
         if (existingAccountInAccounts) {
           form.setError('company_name', {
@@ -177,8 +189,11 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
             designation_of_contact_person: data.designation_of_contact_person,
             email_address_of_contact_person:
               data.email_address_of_contact_person,
-            created_by: user?.id,
-            operation_type: 'insert',
+            ...(user?.user_metadata?.department === 'marketing' && {
+              // marketing needs to add this since they are inserting a row to pending_accounts instead of accounts
+              created_by: user?.id,
+              operation_type: 'insert',
+            }),
           },
         ])
       })(e)

--- a/src/app/(dashboard)/(home)/accounts/data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/data-table.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import ExportAccountRequests from '@/app/(dashboard)/(home)/accounts/export-requests/export-account-requests'
+import ExportAccountsModal from '@/app/(dashboard)/(home)/accounts/export-requests/export-accounts-modal'
+import AccountRequest from '@/app/(dashboard)/(home)/accounts/request/account-request'
 import {
   PageDescription,
   PageHeader,
@@ -18,6 +21,8 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useToast } from '@/components/ui/use-toast'
+import { useUserServer } from '@/providers/UserProvider'
+import getAccounts from '@/queries/get-accounts'
 import { createBrowserClient } from '@/utils/supabase'
 import { useQuery } from '@supabase-cache-helpers/postgrest-react-query'
 import {
@@ -35,10 +40,6 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import AccountsProvider from './accounts-provider'
 import AddAccountButton from './add-account-button'
-import getAccounts from '@/queries/get-accounts'
-import AccountRequest from '@/app/(dashboard)/(home)/accounts/request/account-request'
-import ExportAccountsModal from '@/app/(dashboard)/(home)/accounts/export-requests/export-accounts-modal'
-import ExportAccountRequests from '@/app/(dashboard)/(home)/accounts/export-requests/export-account-requests'
 
 interface IData {
   id: string
@@ -60,6 +61,7 @@ const DataTable = <TData extends IData, TValue>({
 
   const router = useRouter()
   const { toast } = useToast()
+  const { user } = useUserServer()
 
   const table = useReactTable({
     data,
@@ -158,7 +160,9 @@ const DataTable = <TData extends IData, TValue>({
           </div>
         </PageHeader>
         <div className="flex flex-row">
-          <AccountRequest />
+          {user?.user_metadata?.department === 'marketing' && (
+            <AccountRequest />
+          )}
           <ExportAccountRequests />
           <TableViewOptions table={table} />
         </div>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { createServerClient } from '@/utils/supabase'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { UserProvider } from '@/providers/UserProvider'
 
 interface Props {
   children: ReactNode
@@ -24,15 +25,17 @@ const DashboardLayout: FC<Props> = async ({ children }) => {
   }
 
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        <main>
-          <Header />
-          {children}
-        </main>
-      </SidebarInset>
-    </SidebarProvider>
+    <UserProvider user={user}>
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <main>
+            <Header />
+            {children}
+          </main>
+        </SidebarInset>
+      </SidebarProvider>
+    </UserProvider>
   )
 }
 

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { User } from '@supabase/supabase-js'
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+const useUserServer = () => {
+  const context = useContext(UserContext)
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider')
+  }
+  return context
+}
+
+const UserContext = createContext<{
+  user: User | null
+  setUser: (user: User | null) => void
+}>({
+  user: null,
+  setUser: () => {},
+})
+
+const UserProvider = ({
+  children,
+  user,
+}: {
+  children: ReactNode
+  user: User | null
+}) => {
+  const [currentUser, setCurrentUser] = useState<User | null>(user)
+
+  return (
+    <UserContext.Provider
+      value={{
+        user: currentUser,
+        setUser: setCurrentUser,
+      }}
+    >
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export { UserProvider, useUserServer }

--- a/supabase/migrations/20241128122627_refactor_rls_on_accounts_table.sql
+++ b/supabase/migrations/20241128122627_refactor_rls_on_accounts_table.sql
@@ -1,0 +1,29 @@
+drop policy "Enable insert access for admin" on "public"."accounts";
+
+drop policy "Enable update for admin" on "public"."accounts";
+
+create policy "Enable insert access for some department"
+on "public"."accounts"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text]))))))));
+
+
+create policy "Enable update for some departments"
+on "public"."accounts"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text, 'after-sales'::text, 'under-writing'::text]))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Implemented department-based permissions for account management, allowing marketing users to submit changes for approval while other departments can modify accounts directly.

### What changed?
- Added UserProvider context to manage user state across the application
- Modified account creation and editing logic to handle different department permissions
- Marketing department users now submit changes to `pending_accounts` table
- Other authorized departments can directly modify the `accounts` table
- Updated RLS policies to restrict account modifications to specific departments
- Added conditional rendering of account request features for marketing users
- Improved error handling for duplicate company names

### How to test?
1. Log in as a marketing department user
   - Verify that account changes create pending requests
   - Confirm "Account Request" button is visible
   - Check that success messages indicate pending approval

2. Log in as a non-marketing department user (admin/finance/after-sales/under-writing)
   - Verify direct modifications to accounts
   - Confirm changes apply immediately without pending approval
   - Check that success messages indicate immediate changes

### Why make this change?
To implement proper access control and workflow management based on department roles, ensuring that marketing department changes go through an approval process while maintaining direct access for authorized departments.