### PR TITLE
feat(billing): remove approval workflow for finance users

### DIFF
--- a/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
+++ b/src/app/(dashboard)/(home)/billing-statements/data-table.tsx
@@ -27,7 +27,6 @@ import { Suspense, useState } from 'react'
 
 import AddBillingStatementButton from '@/app/(dashboard)/(home)/billing-statements/add-billing-statement-button'
 import { useBillingContext } from '@/app/(dashboard)/(home)/billing-statements/billing-provider'
-import BillingStatementRequest from '@/app/(dashboard)/(home)/billing-statements/request/billing-statement-request'
 import BillingStatementModal from '@/components/billing-statement/billing-statement-modal'
 import TableSearch from '@/components/table-search'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -89,9 +88,6 @@ const DataTable = <TData, TValue>({
           </div>
         </div>
       </PageHeader>
-      <div>
-        <BillingStatementRequest />
-      </div>
       <div className="flex h-full flex-col justify-between bg-card">
         <div className="h-full rounded-md border">
           <Table>

--- a/src/components/billing-statement/billing-statement-modal.tsx
+++ b/src/components/billing-statement/billing-statement-modal.tsx
@@ -50,6 +50,7 @@ import { useMaskito } from '@maskito/react'
 import {
   useInsertMutation,
   useQuery,
+  useUpsertMutation,
 } from '@supabase-cache-helpers/postgrest-react-query'
 import { format } from 'date-fns'
 import { CalendarIcon, Loader2 } from 'lucide-react'
@@ -106,9 +107,9 @@ const BillingStatementModal = <TData,>({
 
   const { data: accounts } = useQuery(getAllAccounts(supabase))
 
-  const { mutateAsync, isPending } = useInsertMutation(
+  const { mutateAsync, isPending } = useUpsertMutation(
     // @ts-ignore
-    supabase.from('pending_billing_statements'),
+    supabase.from('billing_statements'),
     ['id'],
     null,
     {
@@ -118,11 +119,11 @@ const BillingStatementModal = <TData,>({
         toast({
           variant: 'default',
           title: originalData
-            ? 'Billing Statement update request submitted!'
-            : 'Billing Statement creation request submitted!',
+            ? 'Billing Statement updated!'
+            : 'Billing Statement created!',
           description: originalData
-            ? 'Your request to update the billing statement has been submitted successfully and is awaiting approval.'
-            : 'Your request to create a new billing statement has been submitted successfully and is awaiting approval.',
+            ? 'Your billing statement has been updated.'
+            : 'Your billing statement has been created.',
         })
 
         // if creating new billing statement. then we should reset the form
@@ -154,15 +155,13 @@ const BillingStatementModal = <TData,>({
           {
             ...data,
             // @ts-ignore
-            ...(originalData?.id && { billing_statement_id: originalData.id }),
+            ...(originalData?.id && { id: originalData.id }),
             due_date: data.due_date
               ? normalizeToUTC(new Date(data.due_date))
               : undefined,
             or_date: data.or_date
               ? normalizeToUTC(new Date(data.or_date))
               : undefined,
-            operation_type: originalData ? 'update' : 'insert',
-            created_by: user?.id,
           },
         ])
       })(e)

--- a/supabase/migrations/20241130132345_updated_finance_to_allow_access_to_billing_statements.sql
+++ b/supabase/migrations/20241130132345_updated_finance_to_allow_access_to_billing_statements.sql
@@ -1,0 +1,29 @@
+drop policy "Enable insert access for admin" on "public"."billing_statements";
+
+drop policy "Enable update access for admin" on "public"."billing_statements";
+
+create policy "Enable insert access for finance and admin"
+on "public"."billing_statements"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text]))))))));
+
+
+create policy "Enable update access for finance and admin"
+on "public"."billing_statements"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text]))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Removed the billing statement request workflow and enabled direct creation/updates for finance users

### What changed?
- Removed `BillingStatementRequest` component from the data table
- Updated billing statement modal to directly create/update records in `billing_statements` table instead of `pending_billing_statements`
- Modified database policies to allow finance department users to directly manage billing statements
- Updated success messages to reflect direct creation/updates instead of request workflow

### How to test?
1. Log in as a finance department user
2. Navigate to billing statements
3. Try to create a new billing statement
4. Verify it's created directly without going through approval
5. Edit an existing billing statement
6. Confirm changes are applied immediately
7. Log in as a non-finance user and verify they cannot create/edit billing statements

### Why make this change?
To streamline the billing statement workflow by allowing finance department users to directly manage billing statements without requiring admin approval, reducing administrative overhead while maintaining proper access controls.