### PR TITLE
feat(accounts): add after-sales to pending accounts flow

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-about.tsx
@@ -122,8 +122,8 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
   const { mutateAsync } = useUpsertMutation(
     //@ts-ignore
     supabase.from(
-      user?.user_metadata?.department === 'marketing'
-        ? 'pending_accounts' // marketing needs to insert to pending_accounts instead of accounts
+      ['marketing', 'after-sales'].includes(user?.user_metadata?.department)
+        ? 'pending_accounts' // marketing & after-sales needs to insert to pending_accounts instead of accounts
         : 'accounts',
     ),
     ['id'],
@@ -131,14 +131,16 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
     {
       onSuccess: () => {
         toast({
-          title:
-            user?.user_metadata?.department === 'marketing'
-              ? 'Company details edit request submitted!'
-              : 'Company details edited successfully!',
-          description:
-            user?.user_metadata?.department === 'marketing'
-              ? 'Your request to edit the company details has been submitted successfully and is awaiting approval.'
-              : 'Your company details have been edited successfully.',
+          title: ['marketing', 'after-sales'].includes(
+            user?.user_metadata?.department,
+          )
+            ? 'Company details edit request submitted!'
+            : 'Company details edited successfully!',
+          description: ['marketing', 'after-sales'].includes(
+            user?.user_metadata?.department,
+          )
+            ? 'Your request to edit the company details has been submitted successfully and is awaiting approval.'
+            : 'Your company details have been edited successfully.',
         })
         setEditMode(false)
       },
@@ -221,9 +223,11 @@ const CompanyAbout: FC<Props> = ({ companyId }) => {
                     new Date(data.annual_physical_examination_date),
                   )
                 : null,
-            ...(user?.user_metadata?.department === 'marketing'
+            ...(['marketing', 'after-sales'].includes(
+              user?.user_metadata?.department,
+            )
               ? {
-                  created_by: user.id, // marketing needs to add this since they are inserting to pending_accounts instead of accounts
+                  created_by: user.id, // marketing & after-sales needs to add this since they are inserting to pending_accounts instead of accounts
                   account_id: companyId,
                   operation_type: 'update',
                 }

--- a/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
+++ b/src/app/(dashboard)/(home)/accounts/add-account-form.tsx
@@ -65,8 +65,8 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
   const { mutateAsync, isPending, isSuccess } = useInsertMutation(
     // @ts-ignore
     supabase.from(
-      // marketing needs to insert to pending_accounts instead of accounts
-      user?.user_metadata?.department === 'marketing'
+      // marketing & after-sales needs to insert to pending_accounts instead of accounts
+      ['marketing', 'after-sales'].includes(user?.user_metadata?.department)
         ? 'pending_accounts'
         : 'accounts',
     ),
@@ -75,14 +75,16 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
     {
       onSuccess: () => {
         toast({
-          title:
-            user?.user_metadata?.department === 'marketing'
-              ? 'Account creation request submitted!'
-              : 'Account created successfully!',
-          description:
-            user?.user_metadata?.department === 'marketing'
-              ? 'Your request to create a new account has been submitted successfully and is awaiting approval.'
-              : 'Your account has been created successfully.',
+          title: ['marketing', 'after-sales'].includes(
+            user?.user_metadata?.department,
+          )
+            ? 'Account creation request submitted!'
+            : 'Account created successfully!',
+          description: ['marketing', 'after-sales'].includes(
+            user?.user_metadata?.department,
+          )
+            ? 'Your request to create a new account has been submitted successfully and is awaiting approval.'
+            : 'Your account has been created successfully.',
         })
 
         form.reset()
@@ -189,8 +191,10 @@ const AddAccountForm = ({ setIsOpen }: AddAccountFormProps) => {
             designation_of_contact_person: data.designation_of_contact_person,
             email_address_of_contact_person:
               data.email_address_of_contact_person,
-            ...(user?.user_metadata?.department === 'marketing' && {
-              // marketing needs to add this since they are inserting a row to pending_accounts instead of accounts
+            ...(['marketing', 'after-sales'].includes(
+              user?.user_metadata?.department,
+            ) && {
+              // marketing & after-sales needs to add this since they are inserting a row to pending_accounts instead of accounts
               created_by: user?.id,
               operation_type: 'insert',
             }),

--- a/src/app/(dashboard)/(home)/accounts/data-table.tsx
+++ b/src/app/(dashboard)/(home)/accounts/data-table.tsx
@@ -160,9 +160,9 @@ const DataTable = <TData extends IData, TValue>({
           </div>
         </PageHeader>
         <div className="flex flex-row">
-          {user?.user_metadata?.department === 'marketing' && (
-            <AccountRequest />
-          )}
+          {['marketing', 'after-sales'].includes(
+            user?.user_metadata?.department,
+          ) && <AccountRequest />}
           <ExportAccountRequests />
           <TableViewOptions table={table} />
         </div>

--- a/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
+++ b/src/app/(dashboard)/admin/approval-request/accounts/action-request-button.tsx
@@ -70,6 +70,22 @@ const ActionRequestButton: FC<ActionRequestButtonProps> = ({
 
     // Only insert account if action is approve
     if (action === 'approve') {
+      // if selectedData is insert, then check if the account already exists in accounts
+      if (selectedData.operation_type === 'insert') {
+        const { data } = await supabase
+          .from('accounts')
+          .select('id')
+          .eq('company_name', selectedData.company_name)
+          .maybeSingle()
+        if (data) {
+          toast({
+            title: 'Error',
+            description: 'Account already exists',
+          })
+          return
+        }
+      }
+
       // Insert account
       await upsertAccount([
         {


### PR DESCRIPTION
### TL;DR
Added after-sales department to pending accounts workflow and implemented duplicate company name validation.

### What changed?
- Extended pending accounts functionality to include after-sales department alongside marketing
- Added validation to prevent duplicate company names during account approval
- Updated success messages and notifications to reflect the new department inclusion
- Modified database insertion logic to handle both marketing and after-sales departments

### How to test?
1. Log in as an after-sales user and attempt to create/edit an account
2. Verify the request goes to pending_accounts
3. Try approving an account with a company name that already exists
4. Confirm appropriate success/error messages are displayed
5. Test the same workflow as a marketing user to ensure existing functionality remains

### Why make this change?
To enforce the same approval workflow for after-sales department as marketing, ensuring proper oversight of account changes while preventing duplicate company entries in the system.