### PR TITLE
TIM-789 feat(ui): improve company profile responsive layout

### DIFF
--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-HMO-information.tsx
@@ -31,7 +31,7 @@ const CompanyHmoInformation: FC<CompanyHmoInformationProps> = ({ id }) => {
           <HmoInformationFields />
         </Suspense>
       ) : (
-        <div className="grid grid-cols-2 gap-2 pt-4">
+        <div className="flex flex-col gap-2 pt-4 md:grid md:grid-cols-2">
           <CompanyInformationItem
             label={'HMO Provider'}
             value={

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-account-information.tsx
@@ -33,7 +33,7 @@ const CompanyAccountInformation: FC<CompanyAccountInformationProps> = ({
           <AccountInformationFields />
         </Suspense>
       ) : (
-        <div className="grid grid-cols-2 gap-2 pt-4 lg:grid-cols-1">
+        <div className="flex flex-col gap-2 pt-4 md:grid md:grid-cols-2 lg:grid-cols-1">
           <CompanyInformationItem
             label="Account Type"
             value={

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-contract-information.tsx
@@ -34,7 +34,7 @@ const CompanyContractInformation: FC<CompanyContractInformationProps> = ({
           <ContractInformationFields />
         </Suspense>
       ) : (
-        <div className="grid grid-cols-2 gap-2 pt-4 lg:grid-cols-1">
+        <div className="flex flex-col gap-2 pt-4 md:grid md:grid-cols-2 lg:grid-cols-1">
           <CompanyInformationItem
             label="Initial Contract Value"
             value={formatCurrency(account?.initial_contract_value)}

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/(company profile)/company-information.tsx
@@ -30,7 +30,7 @@ const CompanyInformation: FC<CompanyInformationProps> = ({ id }) => {
           <CompanyInformationFields />
         </Suspense>
       ) : (
-        <div className="grid grid-cols-2 gap-2 pt-4">
+        <div className="flex flex-col gap-2 pt-4 md:grid md:grid-cols-2">
           <CompanyInformationItem
             label="Company Name"
             value={account?.company_name?.toString()}

--- a/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header.tsx
+++ b/src/app/(dashboard)/(home)/accounts/(Personnel)/[id]/company-header.tsx
@@ -24,15 +24,15 @@ const CompanyHeader: FC<CompanyHeaderProps> = ({ id }) => {
   return (
     <div className="flex w-full flex-col bg-background pb-6 drop-shadow-md  xl:mb-0 xl:justify-evenly">
       <div className="h-40 w-full bg-slate-400 object-cover xl:h-80 "></div>
-      <div className="relative mx-auto flex w-full max-w-5xl translate-y-4 flex-col items-center justify-between px-8 pt-16 text-center xl:h-20 xl:translate-y-1 xl:flex-row xl:gap-8 xl:px-0 xl:pt-1 xl:text-left">
+      <div className="relative mx-auto flex w-full max-w-6xl translate-y-4 flex-col items-center justify-between px-8 pt-16 text-center xl:h-28 xl:translate-y-1 xl:flex-row xl:gap-8 xl:px-0 xl:pt-1 xl:text-left">
         <div className="absolute -top-20  mx-auto flex flex-col items-center justify-between rounded-full bg-sky-950 ring-4 ring-background xl:relative xl:top-0 xl:-ml-4 xl:-translate-y-8">
           <InitialsAvatar
             name={account?.company_name || ''}
             className="h-32 w-32 translate-y-10 text-center text-5xl text-white"
           />
         </div>
-        <div className="flex w-full flex-col gap-1">
-          <div className="text-lg font-bold lg:leading-4">
+        <div className="flex w-full flex-col gap-1 ">
+          <div className="text-md text-wrap break-all font-bold lg:leading-4">
             {account?.company_name || ''}
           </div>
           <div className="lg:text-wrap text-xs text-[#64748b]">


### PR DESCRIPTION
### TL;DR
Improved responsive layout for company profile sections and header components

### What changed?
- Converted grid layouts to flex column on mobile for better content stacking
- Added responsive breakpoints for grid layouts on medium and larger screens
- Enhanced company name text wrapping and overflow handling
- Adjusted company header dimensions and spacing
- Updated avatar positioning and container width

### How to test?
1. Navigate to a company profile page
2. Verify layout responsiveness by testing on different screen sizes:
   - Mobile: Content should stack vertically
   - Tablet (md): Should display 2-column grid
   - Desktop (lg/xl): Should maintain proper spacing and grid layouts
3. Test with long company names to ensure proper text wrapping
4. Confirm avatar and header positioning across all breakpoints

### Why make this change?
To enhance the mobile user experience by implementing a more intuitive content layout and improving readability across all device sizes. The previous grid-only layout didn't provide optimal viewing on smaller screens.