### PR TITLE
refactor(accounts): update department RLS policies

### DIFF
--- a/supabase/migrations/20241205055926_refactor_rls_for_accounts.sql
+++ b/supabase/migrations/20241205055926_refactor_rls_for_accounts.sql
@@ -1,0 +1,29 @@
+drop policy "Enable insert access for some department" on "public"."accounts";
+
+drop policy "Enable update for some departments" on "public"."accounts";
+
+create policy "Enable insert access for some department"
+on "public"."accounts"
+as permissive
+for insert
+to authenticated
+with check ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text, 'under-writing'::text]))))))));
+
+
+create policy "Enable update for some departments"
+on "public"."accounts"
+as permissive
+for update
+to authenticated
+using ((EXISTS ( SELECT 1
+   FROM user_profiles
+  WHERE ((user_profiles.user_id = ( SELECT auth.uid() AS uid)) AND (user_profiles.department_id IN ( SELECT departments.id
+           FROM departments
+          WHERE (departments.name = ANY (ARRAY['admin'::text, 'finance'::text, 'under-writing'::text]))))))));
+
+
+


### PR DESCRIPTION
### TL;DR
Updated RLS policies for accounts table to restrict access to specific departments

### What changed?
- Dropped and recreated insert and update policies for the accounts table
- Refined policy conditions to only allow access for users in admin, finance, or under-writing departments
- Policies now verify department access through user_profiles and departments tables

### How to test?
1. Log in as a user from admin, finance, or under-writing department
   - Verify you can insert and update accounts
2. Log in as a user from any other department
   - Verify you cannot insert or update accounts
3. Verify existing records remain accessible according to policy

### Why make this change?
To enforce stricter access control by ensuring only users from authorized departments can modify account data, improving security and data integrity